### PR TITLE
Adds queue limit and encryption salt

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Installation
 -  Make sure you have a `Redis <http://redis.io/>`__ server running
    somewhere
 
-Read the more complete documentation at `http://django-q.readthedocs.org <http://django-q.readthedocs.org>`__
+Read the full documentation at `http://django-q.readthedocs.org <http://django-q.readthedocs.org>`__
 
 
 Configuration
@@ -67,7 +67,7 @@ All configuration settings are optional. e.g:
 
 .. code:: python
 
-    # settings.py
+    # settings.py example
     Q_CLUSTER = {
         'name': 'myproject',
         'workers': 8,
@@ -75,6 +75,8 @@ All configuration settings are optional. e.g:
         'timeout': 60,
         'compress': True,
         'save_limit': 250,
+        'queue_limit: 500,
+        'cpu_affinity': 1,
         'label': 'Django Q',
         'redis': {
             'host': '127.0.0.1',

--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -132,7 +132,7 @@ class Sentinel(object):
         self.pool_size = Conf.WORKERS
         self.pool = []
         self.timeout = timeout
-        self.task_queue = Queue()
+        self.task_queue = Queue(maxsize=Conf.QUEUE_LIMIT) if Conf.QUEUE_LIMIT else Queue()
         self.result_queue = Queue()
         self.event_out = Event()
         self.monitor = Process()
@@ -314,7 +314,7 @@ def pusher(task_queue, event, list_key=Conf.Q_LIST, r=redis_client):
             sleep(10)
             break
         if task:
-            task_queue.put(task[1])
+            task_queue.put(task[1], block=True)
             logger.debug(_('queueing from {}').format(list_key))
         if event.is_set():
             break

--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -314,7 +314,7 @@ def pusher(task_queue, event, list_key=Conf.Q_LIST, r=redis_client):
             sleep(10)
             break
         if task:
-            task_queue.put(task[1], block=True)
+            task_queue.put(task[1])
             logger.debug(_('queueing from {}').format(list_key))
         if event.is_set():
             break

--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -33,6 +33,9 @@ class Conf(object):
     # Failures are always saved
     SAVE_LIMIT = conf.get('save_limit', 250)
 
+    # Maximum number of tasks that each cluster can work on
+    QUEUE_LIMIT = conf.get('queue_limit', None)
+
     # Number of workers in the pool. Default is cpu count. +2 for monitor and pusher
     WORKERS = conf.get('workers', cpu_count())
 

--- a/django_q/signing.py
+++ b/django_q/signing.py
@@ -19,7 +19,7 @@ class SignedPackage(object):
     def dumps(obj, compressed=Conf.COMPRESSED):
         return signing.dumps(obj,
                              key=Conf.SECRET_KEY,
-                             salt='django_q.q',
+                             salt=Conf.PREFIX,
                              compress=compressed,
                              serializer=PickleSerializer)
 
@@ -27,7 +27,7 @@ class SignedPackage(object):
     def loads(obj):
         return signing.loads(obj,
                              key=Conf.SECRET_KEY,
-                             salt='django_q.q',
+                             salt=Conf.PREFIX,
                              serializer=PickleSerializer)
 
 

--- a/docs/cluster.rst
+++ b/docs/cluster.rst
@@ -160,7 +160,8 @@ Afterwards the sentinel waits for the monitor to empty the result and then the s
 - Signal that we have stopped
 
 .. warning::
-    If you force the cluster to terminate before the stop procedure has completed, you can lose tasks or results still being held in the queues.
+    If you force the cluster to terminate before the stop procedure has completed, you can lose tasks or results still being held in memory.
+    You can manage the amount of tasks in a clusters memory by setting the :ref:`queue_limit`.
 
 Reference
 ---------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -37,6 +37,7 @@ Configuration is handled via the ``Q_CLUSTER`` dictionary in your :file:`setting
         'timeout': 60,
         'compress': True,
         'save_limit': 250,
+        'queue_limit: 500,
         'cpu_affinity': 1,
         'label': 'Django Q',
         'redis': {
@@ -44,7 +45,6 @@ Configuration is handled via the ``Q_CLUSTER`` dictionary in your :file:`setting
             'port': 6379,
             'db': 0, }
     }
-
 
 
 name

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -91,6 +91,16 @@ Limits the amount of successful tasks saved to Django.
  - Defaults to ``250``
  - Failures are always saved.
 
+.. _queue_limit:
+
+queue_limit
+~~~~~~~~~~~
+
+This does not limit the amount of tasks that can be queued overall on Redis, but rather how many tasks are kept in memory by a single cluster.
+Setting this to a reasonable number, can help balance the workload and the memory overhead of each individual cluster.
+It can also be used to manage the loss of data in case of a cluster failure.
+Defaults to ``None``, meaning no limit.
+
 label
 ~~~~~
 

--- a/docs/monitor.rst
+++ b/docs/monitor.rst
@@ -46,6 +46,7 @@ TQ
 **Task Queue** counts the number of tasks in the queue
 
 If this keeps rising it means you are taking on more tasks than your cluster can handle.
+You can limit this by settings the :ref:`queue_limit` in your cluster configuration.
 
 RQ
 ~~
@@ -58,7 +59,7 @@ It's normal for the result queue to take slightly longer to clear than the task 
 RC
 ~~
 
-**Reincarnations** shows the amount of processes that have been reincarnated after a sudden death or timeout.
+**Reincarnations** shows the amount of processes that have been reincarnated after a recycle, sudden death or timeout.
 If this number is unusually high, you are either suffering from repeated task errors or severe timeouts and you should check your logs for details.
 
 Up
@@ -124,9 +125,9 @@ Reference
 
     .. py:attribute:: pusher
 
-    The pid of the pushes process
+    The pid of the pusher process
 
-    .. py:attribute:: monitor
+    .. py:attribute:: monitormight
 
     The pid of the monitor process
 

--- a/docs/monitor.rst
+++ b/docs/monitor.rst
@@ -127,7 +127,7 @@ Reference
 
     The pid of the pusher process
 
-    .. py:attribute:: monitormight
+    .. py:attribute:: monitor
 
     The pid of the monitor process
 


### PR DESCRIPTION
* adds `queue_limit` configuration option to manage the amount of tasks held in memory by a cluster.
* task package signing is now salted with the configuration name.
* adds docs for this