### PR TITLE
Group filter and queue limit indicator

### DIFF
--- a/django_q/admin.py
+++ b/django_q/admin.py
@@ -26,6 +26,7 @@ class TaskAdmin(admin.ModelAdmin):
 
     search_fields = ('name', 'func', 'group')
     readonly_fields = []
+    list_filter = ('group',)
 
     def get_readonly_fields(self, request, obj=None):
         return list(self.readonly_fields) + \
@@ -56,6 +57,7 @@ class FailAdmin(admin.ModelAdmin):
 
     actions = [retry_failed]
     search_fields = ('name', 'func')
+    list_filter = ('group',)
     readonly_fields = []
 
     def get_readonly_fields(self, request, obj=None):

--- a/django_q/monitor.py
+++ b/django_q/monitor.py
@@ -53,9 +53,11 @@ def monitor(run_once=False):
                 elif stat.status == Conf.IDLE:
                     status = str(Conf.IDLE)
                 # color q's
-                tasks = stat.task_q_size
-                if tasks > 0:
-                    tasks = term.cyan(str(tasks))
+                tasks = str(stat.task_q_size)
+                if stat.task_q_size > 0:
+                    tasks = term.cyan(str(stat.task_q_size))
+                    if Conf.QUEUE_LIMIT and stat.task_q_size == Conf.QUEUE_LIMIT:
+                        tasks = term.green(str(stat.task_q_size))
                 results = stat.done_q_size
                 if results > 0:
                     results = term.cyan(str(results))


### PR DESCRIPTION
* adds group filters to the Failure and Success admin views
* monitor TQ will turn green if queue_limit is reached