### PR TITLE
#79  close django db connection before fork

### DIFF
--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -188,6 +188,7 @@ class Sentinel(object):
     def spawn_cluster(self):
         self.pool = []
         Stat(self).save()
+        db.connection.close()
         # spawn worker pool
         for __ in range(self.pool_size):
             self.spawn_worker()


### PR DESCRIPTION
The sentinel saves a statistic to the cache provider just before forking the workers. If this cache provider is a database backend, the connection stays open and gets forked and it crashes. Solution is to close any db connection before forking.