### PR TITLE
Adds cached result backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Features
 -  Asynchronous tasks
 -  Scheduled and repeated tasks
 -  Encrypted and compressed packages
--  Failure and success database
+-  Failure and success database or cache
 -  Result hooks and groups
 -  Django Admin integration
 -  PaaS compatible with multiple instances

--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -113,6 +113,10 @@ class Conf(object):
     # The Django cache to use
     CACHE = conf.get('cache', 'default')
 
+    # Use the cache as result backend. Can be 'True' or an integer representing the global cache timeout.
+    # i.e 'cached: 60' , will make all results go the cache and expire in 60 seconds.
+    CACHED = conf.get('cached', False)
+
     # If set to False the scheduler won't execute tasks in the past.
     # Instead it will run once and reschedule the next run in the future. Defaults to True.
     CATCH_UP = conf.get('catch_up', True)

--- a/django_q/tasks.py
+++ b/django_q/tasks.py
@@ -23,6 +23,7 @@ def async(func, *args, **kwargs):
     sync = options.pop('sync', False)
     group = options.pop('group', None)
     save = options.pop('save', None)
+    cached = options.pop('cached', Conf.CACHED)
     # get an id
     tag = uuid()
     # build the task package
@@ -38,6 +39,8 @@ def async(func, *args, **kwargs):
         task['group'] = group
     if save is not None:
         task['save'] = save
+    if cached:
+        task['cached'] = cached
     # sign it
     pack = signing.SignedPackage.dumps(task)
     if sync or Conf.SYNC:
@@ -83,7 +86,7 @@ def schedule(func, *args, **kwargs):
                                    )
 
 
-def result(task_id, wait=0):
+def result(task_id, wait=0, cached=Conf.CACHED):
     """
     Return the result of the named task.
 
@@ -94,6 +97,8 @@ def result(task_id, wait=0):
     :return: the result object of this task
     :rtype: object
     """
+    if cached:
+        return result_cached(task_id, wait)
     start = time.time()
     while True:
         r = Task.get_result(task_id)
@@ -104,7 +109,21 @@ def result(task_id, wait=0):
         time.sleep(0.01)
 
 
-def result_group(group_id, failures=False):
+def result_cached(task_id, wait=0, broker=None):
+    if not broker:
+        broker = get_broker()
+    key = 'django_q:{}:results'.format(broker.list_key)
+    start = time.time()
+    while True:
+        r = broker.cache.get('{}:{}'.format(key, task_id))
+        if r:
+            return signing.SignedPackage.loads(r)['result']
+        if (time.time() - start) * 1000 >= wait:
+            break
+        time.sleep(0.01)
+
+
+def result_group(group_id, failures=False, cached=Conf.CACHED):
     """
     Return a list of results for a task group.
 
@@ -112,10 +131,26 @@ def result_group(group_id, failures=False):
     :param bool failures: set to True to include failures
     :return: list or results
     """
+    if cached:
+        return result_group_cached(group_id, failures)
     return Task.get_result_group(group_id, failures)
 
 
-def fetch(task_id, wait=0):
+def result_group_cached(group_id, failures=False, broker=None):
+    if not broker:
+        broker = get_broker()
+    key = 'django_q:{}:results'.format(broker.list_key)
+    group_list = broker.cache.get('{}:{}'.format(key, group_id))
+    if group_list:
+        result_list = []
+        for task_package in group_list:
+            task = signing.SignedPackage.loads(task_package)
+            if task['success'] or failures:
+                result_list.append(task['result'])
+        return result_list
+
+
+def fetch(task_id, wait=0, cached=Conf.CACHED):
     """
     Return the processed task.
 
@@ -126,6 +161,8 @@ def fetch(task_id, wait=0):
     :return: the full task object
     :rtype: Task
     """
+    if cached:
+        return fetch_cached(task_id, wait)
     start = time.time()
     while True:
         t = Task.get_task(task_id)
@@ -136,7 +173,32 @@ def fetch(task_id, wait=0):
         time.sleep(0.01)
 
 
-def fetch_group(group_id, failures=True):
+def fetch_cached(task_id, wait=0, broker=None):
+    if not broker:
+        broker = get_broker()
+    key = 'django_q:{}:results'.format(broker.list_key)
+    start = time.time()
+    while True:
+        r = broker.cache.get('{}:{}'.format(key, task_id))
+        if r:
+            task = signing.SignedPackage.loads(r)
+            t = Task(id=task['id'],
+                     name=task['name'],
+                     func=task['func'],
+                     hook=task.get('hook'),
+                     args=task['args'],
+                     kwargs=task['kwargs'],
+                     started=task['started'],
+                     stopped=task['stopped'],
+                     result=task['result'],
+                     success=task['success'])
+            return t
+        if (time.time() - start) * 1000 >= wait:
+            break
+        time.sleep(0.01)
+
+
+def fetch_group(group_id, failures=True, cached=True):
     """
     Return a list of Tasks for a task group.
 
@@ -144,10 +206,37 @@ def fetch_group(group_id, failures=True):
     :param bool failures: set to False to exclude failures
     :return: list of Tasks
     """
+    if cached:
+        return fetch_group_cached(group_id, failures)
     return Task.get_task_group(group_id, failures)
 
 
-def count_group(group_id, failures=False):
+def fetch_group_cached(group_id, failures=True, broker=None):
+    if not broker:
+        broker = get_broker()
+    key = 'django_q:{}:results'.format(broker.list_key)
+    group_list = broker.cache.get('{}:{}'.format(key, group_id))
+    if group_list:
+        task_list = []
+        for task_package in group_list:
+            task = signing.SignedPackage.loads(task_package)
+            if task['success'] or failures:
+                t = Task(id=task['id'],
+                         name=task['name'],
+                         func=task['func'],
+                         hook=task.get('hook'),
+                         args=task['args'],
+                         kwargs=task['kwargs'],
+                         started=task['started'],
+                         stopped=task['stopped'],
+                         result=task['result'],
+                         group=task.get('group'),
+                         success=task['success'])
+                task_list.append(t)
+        return task_list
+
+
+def count_group(group_id, failures=False, cached=Conf.CACHED):
     """
     Count the results in a group.
 
@@ -156,10 +245,28 @@ def count_group(group_id, failures=False):
     :return: the number of tasks/results in a group
     :rtype: int
     """
+    if cached:
+        return count_group_cached(group_id, failures)
     return Task.get_group_count(group_id, failures)
 
 
-def delete_group(group_id, tasks=False):
+def count_group_cached(group_id, failures=False, broker=None):
+    if not broker:
+        broker = get_broker()
+    key = 'django_q:{}:results'.format(broker.list_key)
+    group_list = broker.cache.get('{}:{}'.format(key, group_id))
+    if group_list:
+        if not failures:
+            return len(group_list)
+        failure_count = 0
+        for task_package in group_list:
+            task = signing.SignedPackage.loads(task_package)
+            if not task['success']:
+                failure_count += 1
+        return failure_count
+
+
+def delete_group(group_id, tasks=False, cached=Conf.CACHE):
     """
     Delete a group.
 
@@ -168,7 +275,16 @@ def delete_group(group_id, tasks=False):
     Otherwise just the group label is removed.
     :return:
     """
+    if cached:
+        return delete_group_cached(group_id)
     return Task.delete_group(group_id, tasks)
+
+
+def delete_group_cached(group_id, broker=None):
+    if not broker:
+        broker = get_broker()
+    key = 'django_q:{}:results'.format(broker.list_key)
+    return broker.cache.delete('{}:{}'.format(key, group_id))
 
 
 def queue_size(broker=None):

--- a/django_q/tasks.py
+++ b/django_q/tasks.py
@@ -1,4 +1,4 @@
-"""Provides task functionalities."""
+"""Provides task functionality."""
 from multiprocessing import Queue, Value
 
 # django
@@ -94,6 +94,7 @@ def result(task_id, wait=0, cached=Conf.CACHED):
     :param task_id: the task name or uuid
     :type wait: int
     :param wait: number of milliseconds to wait for a result
+    :param cached: run this against the cache backend
     :return: the result object of this task
     :rtype: object
     """
@@ -110,6 +111,9 @@ def result(task_id, wait=0, cached=Conf.CACHED):
 
 
 def result_cached(task_id, wait=0, broker=None):
+    """
+     Return the result from the cache backend
+    """
     if not broker:
         broker = get_broker()
     key = 'django_q:{}:results'.format(broker.list_key)
@@ -129,6 +133,7 @@ def result_group(group_id, failures=False, cached=Conf.CACHED):
 
     :param str group_id: the group id
     :param bool failures: set to True to include failures
+    :param cached: run this against the cache backend
     :return: list or results
     """
     if cached:
@@ -137,6 +142,9 @@ def result_group(group_id, failures=False, cached=Conf.CACHED):
 
 
 def result_group_cached(group_id, failures=False, broker=None):
+    """
+    Return a list of results for a task group from the cache backend
+    """
     if not broker:
         broker = get_broker()
     key = 'django_q:{}:results'.format(broker.list_key)
@@ -158,6 +166,7 @@ def fetch(task_id, wait=0, cached=Conf.CACHED):
     :type task_id: str or uuid
     :param wait: the number of milliseconds to wait for a result
     :type wait: int
+    :param cached: run this against the cache backend
     :return: the full task object
     :rtype: Task
     """
@@ -174,6 +183,9 @@ def fetch(task_id, wait=0, cached=Conf.CACHED):
 
 
 def fetch_cached(task_id, wait=0, broker=None):
+    """
+    Return the processed task from the cache backend
+    """
     if not broker:
         broker = get_broker()
     key = 'django_q:{}:results'.format(broker.list_key)
@@ -198,12 +210,13 @@ def fetch_cached(task_id, wait=0, broker=None):
         time.sleep(0.01)
 
 
-def fetch_group(group_id, failures=True, cached=False):
+def fetch_group(group_id, failures=True, cached=Conf.CACHED):
     """
     Return a list of Tasks for a task group.
 
     :param str group_id: the group id
     :param bool failures: set to False to exclude failures
+    :param cached: run this against the cache backend
     :return: list of Tasks
     """
     if cached:
@@ -212,6 +225,9 @@ def fetch_group(group_id, failures=True, cached=False):
 
 
 def fetch_group_cached(group_id, failures=True, broker=None):
+    """
+    Return a list of Tasks for a task group in the cache backend
+    """
     if not broker:
         broker = get_broker()
     key = 'django_q:{}:results'.format(broker.list_key)
@@ -242,6 +258,7 @@ def count_group(group_id, failures=False, cached=Conf.CACHED):
 
     :param str group_id: the group id
     :param bool failures: Returns failure count if True
+    :param cached: run this against the cache backend
     :return: the number of tasks/results in a group
     :rtype: int
     """
@@ -251,6 +268,9 @@ def count_group(group_id, failures=False, cached=Conf.CACHED):
 
 
 def count_group_cached(group_id, failures=False, broker=None):
+    """
+    Count the results in a group in the cache backend
+    """
     if not broker:
         broker = get_broker()
     key = 'django_q:{}:results'.format(broker.list_key)
@@ -273,6 +293,7 @@ def delete_group(group_id, tasks=False, cached=Conf.CACHED):
     :param str group_id: the group id
     :param bool tasks: If set to True this will also delete the group tasks.
     Otherwise just the group label is removed.
+    :param cached: run this against the cache backend
     :return:
     """
     if cached:
@@ -281,12 +302,18 @@ def delete_group(group_id, tasks=False, cached=Conf.CACHED):
 
 
 def delete_group_cached(group_id, broker=None):
+    """
+    Delete a group from the cache backend
+    """
     if not broker:
         broker = get_broker()
     return delete_cached(group_id, broker)
 
 
 def delete_cached(task_id, broker=None):
+    """
+    Delete a task from the cache backend
+    """
     if not broker:
         broker = get_broker()
     key = 'django_q:{}:results'.format(broker.list_key)

--- a/django_q/tasks.py
+++ b/django_q/tasks.py
@@ -198,7 +198,7 @@ def fetch_cached(task_id, wait=0, broker=None):
         time.sleep(0.01)
 
 
-def fetch_group(group_id, failures=True, cached=True):
+def fetch_group(group_id, failures=True, cached=False):
     """
     Return a list of Tasks for a task group.
 

--- a/django_q/tasks.py
+++ b/django_q/tasks.py
@@ -266,7 +266,7 @@ def count_group_cached(group_id, failures=False, broker=None):
         return failure_count
 
 
-def delete_group(group_id, tasks=False, cached=Conf.CACHE):
+def delete_group(group_id, tasks=False, cached=Conf.CACHED):
     """
     Delete a group.
 

--- a/django_q/tasks.py
+++ b/django_q/tasks.py
@@ -283,8 +283,14 @@ def delete_group(group_id, tasks=False, cached=Conf.CACHED):
 def delete_group_cached(group_id, broker=None):
     if not broker:
         broker = get_broker()
+    return delete_cached(group_id, broker)
+
+
+def delete_cached(task_id, broker=None):
+    if not broker:
+        broker = get_broker()
     key = 'django_q:{}:results'.format(broker.list_key)
-    return broker.cache.delete('{}:{}'.format(key, group_id))
+    return broker.cache.delete('{}:{}'.format(key, task_id))
 
 
 def queue_size(broker=None):

--- a/django_q/tests/test_cached.py
+++ b/django_q/tests/test_cached.py
@@ -4,7 +4,7 @@ import pytest
 
 from django_q.cluster import Sentinel
 from django_q.conf import Conf
-from django_q.tasks import async, result, fetch, count_group, result_group, fetch_group, delete_group
+from django_q.tasks import async, result, fetch, count_group, result_group, fetch_group, delete_group, delete_cached
 from django_q.brokers import get_broker
 
 
@@ -54,4 +54,7 @@ def test_cached(broker):
     assert len(fetch_group(group, cached=True, failures=False)) == 5
     delete_group(group, cached=True)
     assert count_group(group, cached=True) is None
+    delete_cached(task_id)
+    assert result(task_id, cached=True) is None
+    assert fetch(task_id, cached=True) is None
     broker.cache.clear()

--- a/django_q/tests/test_cached.py
+++ b/django_q/tests/test_cached.py
@@ -1,0 +1,52 @@
+from multiprocessing import Event
+
+import pytest
+
+from django_q.cluster import Sentinel
+from django_q.conf import Conf
+from django_q.tasks import async, result, fetch, count_group, result_group, fetch_group, delete_group
+from django_q.brokers import get_broker
+
+
+@pytest.fixture
+def broker():
+    Conf.DISQUE_NODES = None
+    Conf.IRON_MQ = None
+    Conf.SQS = None
+    Conf.ORM = None
+    Conf.MONGO = None
+    Conf.DJANGO_REDIS = 'default'
+    return get_broker()
+
+
+@pytest.mark.django_db
+def test_cached(broker):
+    broker.purge_queue()
+    broker.cache.clear()
+    group = 'cache_test'
+    # queue the tests
+    task_id = async('math.copysign', 1, -1, cached=True, broker=broker)
+    async('math.copysign', 1, -1, cached=True, broker=broker, group=group)
+    async('math.copysign', 1, -1, cached=True, broker=broker, group=group)
+    async('math.copysign', 1, -1, cached=True, broker=broker, group=group)
+    async('math.copysign', 1, -1, cached=True, broker=broker, group=group)
+    async('math.copysign', 1, -1, cached=True, broker=broker, group=group)
+    # run a single cluster
+    start_event = Event()
+    stop_event = Event()
+    stop_event.set()
+    Sentinel(stop_event, start_event, broker=broker)
+    # assert results
+    assert result(task_id, wait=500, cached=True) == -1
+    assert fetch(task_id,wait=500, cached=True).result == -1
+    # make sure it's not in the db backend
+    assert fetch(task_id) is None
+    # assert group
+    assert count_group(group, cached=True) == 5
+    assert count_group(group, cached=True, failures=True) == 0
+    assert result_group(group, cached=True) == [-1, -1, -1, -1, -1]
+    assert len(fetch_group(group, cached=True)) == 5
+    assert len(fetch_group(group, cached=True, failures=False)) == 5
+    delete_group(group, cached=True)
+    assert count_group(group, cached=True) is None
+    broker.cache.clear()

--- a/django_q/tests/test_cached.py
+++ b/django_q/tests/test_cached.py
@@ -80,6 +80,7 @@ def test_iter(broker):
     result_t = result(t)
     assert result_t is not None
     task_t = fetch(t)
+    assert task_t. __unicode__ is not None
     assert task_t.result == result_t
     assert result(t2) is not None
     assert result(t3) is not None

--- a/django_q/tests/test_cached.py
+++ b/django_q/tests/test_cached.py
@@ -31,6 +31,10 @@ def test_cached(broker):
     async('math.copysign', 1, -1, cached=True, broker=broker, group=group)
     async('math.copysign', 1, -1, cached=True, broker=broker, group=group)
     async('math.copysign', 1, -1, cached=True, broker=broker, group=group)
+    async('math.popysign', 1, -1, cached=True, broker=broker, group=group)
+    # test wait on cache
+    assert result(task_id, wait=1, cached=True) is None
+    assert fetch(task_id, wait=1, cached=True) is None
     # run a single cluster
     start_event = Event()
     stop_event = Event()
@@ -42,10 +46,11 @@ def test_cached(broker):
     # make sure it's not in the db backend
     assert fetch(task_id) is None
     # assert group
-    assert count_group(group, cached=True) == 5
-    assert count_group(group, cached=True, failures=True) == 0
+    assert count_group(group, cached=True) == 6
+    assert count_group(group, cached=True, failures=True) == 1
     assert result_group(group, cached=True) == [-1, -1, -1, -1, -1]
-    assert len(fetch_group(group, cached=True)) == 5
+    assert len(result_group(group, cached=True, failures=True)) == 6
+    assert len(fetch_group(group, cached=True)) == 6
     assert len(fetch_group(group, cached=True, failures=False)) == 5
     delete_group(group, cached=True)
     assert count_group(group, cached=True) is None

--- a/django_q/tests/test_cached.py
+++ b/django_q/tests/test_cached.py
@@ -33,8 +33,13 @@ def test_cached(broker):
     async('math.copysign', 1, -1, cached=True, broker=broker, group=group)
     async('math.popysign', 1, -1, cached=True, broker=broker, group=group)
     # test wait on cache
-    assert result(task_id, wait=1, cached=True) is None
-    assert fetch(task_id, wait=1, cached=True) is None
+    # test wait timeout
+    assert result(task_id, wait=10, cached=True) is None
+    assert fetch(task_id, wait=10, cached=True) is None
+    assert result_group(group, wait=10, cached=True) is None
+    assert result_group(group, count=2, wait=10, cached=True) is None
+    assert fetch_group(group, wait=10, cached=True) is None
+    assert fetch_group(group, count=2, wait=10, cached=True) is None
     # run a single cluster
     start_event = Event()
     stop_event = Event()
@@ -42,7 +47,7 @@ def test_cached(broker):
     Sentinel(stop_event, start_event, broker=broker)
     # assert results
     assert result(task_id, wait=500, cached=True) == -1
-    assert fetch(task_id,wait=500, cached=True).result == -1
+    assert fetch(task_id, wait=500, cached=True).result == -1
     # make sure it's not in the db backend
     assert fetch(task_id) is None
     # assert group

--- a/django_q/tests/test_cluster.py
+++ b/django_q/tests/test_cluster.py
@@ -160,6 +160,13 @@ def test_async(broker, admin_user):
     assert broker.queue_size() == 0
     assert task_queue.qsize() == task_count
     task_queue.put('STOP')
+    # test wait timeout
+    assert result(j, wait=10) is None
+    assert fetch(j, wait=10) is None
+    assert result_group('test_j', wait=10) is None
+    assert result_group('test_j', count=2, wait=10) is None
+    assert fetch_group('test_j', wait=10) is None
+    assert fetch_group('test_j', count=2, wait=10) is None
     # let a worker handle them
     result_queue = Queue()
     worker(task_queue, result_queue, Value('f', -1))

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -308,6 +308,13 @@ cache
 For some brokers, you will need to set up the Django `cache framework <https://docs.djangoproject.com/en/1.8/topics/cache/#setting-up-the-cache>`__
 to gather statistics for the monitor. You can indicate which cache to use by setting this value. Defaults to ``default``.
 
+.. _cached:
+
+cached
+~~~~~~
+Switches all task and result functions from using the database backend to the cache backend. This is the same as setting the keyword ``cached=True`` on all task functions.
+Instead of a bool this can also be set to the number of seconds you want the cache to retain results. e.g. ``cached=60``
+
 scheduler
 ~~~~~~~~~
 You can disable the scheduler by setting this option to ``False``. This will reduce a little overhead if you're not using schedules, but is most useful if you want to temporarily disable all schedules.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ Features
 -  Asynchronous tasks
 -  Scheduled and repeated tasks
 -  Encrypted and compressed packages
--  Failure and success database
+-  Failure and success database or cache
 -  Result hooks and groups
 -  Django Admin integration
 -  PaaS compatible with multiple instances

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -89,6 +89,28 @@ Please not that this will override any other option keywords.
     For tasks to be processed you will need to have a worker cluster running in the background using ``python manage.py qcluster``
     or you need to configure Django Q to run in synchronous mode for testing using the :ref:`sync` option.
 
+
+
+Async Iterable
+--------------
+If you have an iterable object with arguments for a function, you can use :func:`async_iter` to async them with a single command::
+
+    # Async Iterable example
+    from django_q.tasks import async_iter, result
+
+    # set up a list of arguments for math.floor
+    iter = [i for i in range(100)]
+
+    # async iter them
+    id=async_iter('math.floor',iter)
+
+    # wait for the collated result for 1 second
+    result_list = result(id, wait=1000)
+
+This will individually queue 100 tasks to the worker cluster, which will save their results in the cache backend for speed.
+Once all the 100 results are in the cache, they are collated into a list and saved as a single result in the database. The cache results are then cleared.
+Needs the Django cache framework.
+
 .. _groups:
 
 Groups
@@ -103,13 +125,15 @@ You can group together results by passing :func:`async` the optional ``group`` k
     for i in range(4):
         async('math.modf', i, group='modf')
 
-    # after the tasks have finished you can get the group results
-    result = result_group('modf')
+    # wait until the group has 4 results
+    result = result_group('modf', count=4)
     print(result)
 
 .. code-block:: python
 
     [(0.0, 0.0), (0.0, 1.0), (0.0, 2.0), (0.0, 3.0)]
+
+Note that the same can be achieved much faster with :func:`async_iter`
 
 Take care to not limit your results database too much and call :func:`delete_group` before each run, unless you want your results to keep adding up.
 Instead of :func:`result_group` you can also use :func:`fetch_group` to return a queryset of :class:`Task` objects.:
@@ -163,7 +187,7 @@ By using a cache backend like Redis or Memcached you can speed up access to your
 
 When you set ``cached=True``, results will be saved permanently in the cache and you will have to rely on your backend's cleanup strategies (like LRU) to
 manage stale results.
-You can however opt to set a manual timeout on the results, by setting ``cached=60``. Meaning the result will be evicted from the cache after 60 seconds.
+You can also opt to set a manual timeout on the results, by setting ``cached=60``. Meaning the result will be evicted from the cache after 60 seconds.
 This works both globally or on individual async executions.::
 
     # simple cached example
@@ -174,6 +198,12 @@ This works both globally or on individual async executions.::
 
     # wait max 50ms for the result to appear in the cache
     result(id, wait=50, cached=True)
+
+    # o fetch the task object
+    task = fetch(id, cache=True)
+
+    # and then save it to the database
+    task.save()
 
 This also works for group actions::
 
@@ -195,6 +225,7 @@ This also works for group actions::
     # wait max 50ms for one hundred results to return
     result_group('frexp', wait=50, count=100, cached=True)
 
+Note that exact same result can be achieved by using the more convenient :func:`async_iter` in this case, but without hook support.
 
 Synchronous testing
 -------------------
@@ -286,6 +317,16 @@ Reference
     .. versionchanged:: 0.2.0
 
     Renamed from get_task
+
+.. py:function:: async_iter(func, args_iter,**kwargs)
+
+   Runs iterable arguments against the cache backend and returns a single collated result
+
+   :param object func: The task function to execute
+   :param args: An iterable containing arguments for the task function
+   :param dict kwargs: Keyword arguments for the task function. Ignores ``cached`` and ``hook``.
+   :returns: The uuid of the task
+   :rtype: str
 
 .. py:function:: queue_size()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 arrow==0.6.0
 blessed==1.9.5
 boto3==1.1.4
-botocore==1.2.6           # via boto3
+botocore==1.2.7           # via boto3
 django-picklefield==0.3.2
 django-redis==4.2.0
 docutils==0.12            # via botocore
@@ -16,7 +16,7 @@ futures==2.2.0            # via boto3
 hiredis==0.2.0
 iron-core==1.1.9          # via iron-mq
 iron-mq==0.7
-jmespath==0.8.0           # via boto3, botocore
+jmespath==0.9.0           # via boto3, botocore
 msgpack-python==0.4.6     # via django-redis
 psutil==3.2.1
 pymongo==3.0.3


### PR DESCRIPTION

* Adds a global and per-task ``cached` option, which will redirect any results to the cache backend.
* Adds ``count`` option for groups results which will block until the indicated amount of results in the group has been reached
* Adds ``wait`` option for group results. Can be used in conjunction with ``count``
* Adds ``async_iter()`` command which takes an iterable set of arguments, asyncs them individualy against the cache backend and collates them back in to a single database result.
