### PR TITLE
moves hook signal in separate module

### DIFF
--- a/django_q/apps.py
+++ b/django_q/apps.py
@@ -6,3 +6,6 @@ from .conf import Conf
 class DjangoQConfig(AppConfig):
     name = 'django_q'
     verbose_name = Conf.LABEL
+
+    def ready(self):
+        from django_q.signals import call_hook

--- a/django_q/models.py
+++ b/django_q/models.py
@@ -1,12 +1,7 @@
-import logging
-
 from django import get_version
-import importlib
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.db import models
-from django.db.models.signals import post_save
-from django.dispatch import receiver
 from django.utils import timezone
 from picklefield import PickledObjectField
 from picklefield.fields import dbsafe_decode
@@ -89,25 +84,6 @@ class Task(models.Model):
     class Meta:
         app_label = 'django_q'
         ordering = ['-stopped']
-
-
-@receiver(post_save, sender=Task)
-def call_hook(sender, instance, **kwargs):
-    if instance.hook:
-        logger = logging.getLogger('django-q')
-        f = instance.hook
-        if not callable(f):
-            try:
-                module, func = f.rsplit('.', 1)
-                m = importlib.import_module(module)
-                f = getattr(m, func)
-            except (ValueError, ImportError, AttributeError):
-                logger.error(_('malformed return hook \'{}\' for [{}]').format(instance.hook, instance.name))
-                return
-        try:
-            f(instance)
-        except Exception as e:
-            logger.error(_('return hook {} failed on [{}] because {}').format(instance.hook, instance.name, e))
 
 
 class SuccessManager(models.Manager):

--- a/django_q/signals.py
+++ b/django_q/signals.py
@@ -1,0 +1,27 @@
+import importlib
+import logging
+
+from django.utils.translation import ugettext_lazy as _
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from django_q.models import Task
+
+
+@receiver(post_save, sender=Task)
+def call_hook(sender, instance, **kwargs):
+    if instance.hook:
+        logger = logging.getLogger('django-q')
+        f = instance.hook
+        if not callable(f):
+            try:
+                module, func = f.rsplit('.', 1)
+                m = importlib.import_module(module)
+                f = getattr(m, func)
+            except (ValueError, ImportError, AttributeError):
+                logger.error(_('malformed return hook \'{}\' for [{}]').format(instance.hook, instance.name))
+                return
+        try:
+            f(instance)
+        except Exception as e:
+            logger.error(_('return hook {} failed on [{}] because {}').format(instance.hook, instance.name, e))


### PR DESCRIPTION
By moving signals in their own module, we can now follow Django guidelines and register signals on app.ready.