### PR TITLE
adds `cached` option to `async_iter`

### DIFF
--- a/django_q/tasks.py
+++ b/django_q/tasks.py
@@ -25,6 +25,7 @@ def async(func, *args, **kwargs):
     save = options.pop('save', None)
     cached = options.pop('cached', Conf.CACHED)
     iter_count = options.pop('iter_count', None)
+    iter_cached = options.pop('iter_cached', None)
     # get an id
     tag = uuid()
     # build the task package
@@ -44,6 +45,8 @@ def async(func, *args, **kwargs):
         task['cached'] = cached
     if iter_count:
         task['iter_count'] = iter_count
+    if iter_cached:
+        task['iter_cached'] = iter_cached
     # sign it
     pack = signing.SignedPackage.dumps(task)
     if sync or Conf.SYNC:
@@ -388,6 +391,8 @@ def async_iter(func, args_iter, **kwargs):
     options['broker'] = options.get('broker', get_broker())
     options['group'] = iter_group
     options['iter_count'] = iter_count
+    if options.get('cached', None):
+        options['iter_cached'] = options['cached']
     options['cached'] = True
     # save the original arguments
     broker = options['broker']

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -320,11 +320,12 @@ Reference
 
 .. py:function:: async_iter(func, args_iter,**kwargs)
 
-   Runs iterable arguments against the cache backend and returns a single collated result
+   Runs iterable arguments against the cache backend and returns a single collated result.
+   Accepts the same options as :func:`async` except ``hook``.
 
    :param object func: The task function to execute
    :param args: An iterable containing arguments for the task function
-   :param dict kwargs: Keyword arguments for the task function. Ignores ``cached`` and ``hook``.
+   :param dict kwargs: Keyword arguments for the task function. Ignores ``hook``.
    :returns: The uuid of the task
    :rtype: str
 


### PR DESCRIPTION
* an `async_iter` result can now also be cached permanently or with a timeout
* improved cached testing