### PR TITLE
Adds timeout to group key cache object

### DIFF
--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -450,7 +450,7 @@ def save_cached(task, broker):
                 return
             # save the group list
             group_list.append(task_key)
-            broker.cache.set(group_key, group_list)
+            broker.cache.set(group_key, group_list, timeout)
             # async next in a chain
             if task.get('chain', None):
                 tasks.async_chain(task['chain'], group=group, cached=task['cached'], sync=task['sync'], broker=broker)

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -123,7 +123,7 @@ At the moment this means we support the 1.7.10 and 1.8.5 releases.
 Once version 1.9 is out , support for Django 1.7 will be deprecated.
 This will mean that newer releases of Django Q might still work, but are no longer targeted for testing.
 
-Django Q has been tested with Django 1.9a1 and should be compatible.
+Django Q has been tested with Django 1.9b1 and should be compatible.
 
 
 


### PR DESCRIPTION
* Fixes a bug where the group key list wouldn't time out with the keys and thus referencing times out keys
* Tested with Django 1.9b1