### PR TITLE
Add broker name in Schedule

### DIFF
--- a/django_q/admin.py
+++ b/django_q/admin.py
@@ -80,6 +80,7 @@ class ScheduleAdmin(admin.ModelAdmin):
     list_display = (
         'id',
         'name',
+        'broker_name',
         'func',
         'schedule_type',
         'repeats',
@@ -88,7 +89,7 @@ class ScheduleAdmin(admin.ModelAdmin):
         'success'
     )
 
-    list_filter = ('next_run', 'schedule_type')
+    list_filter = ('next_run', 'broker_name', 'schedule_type')
     search_fields = ('func',)
     list_display_links = ('id', 'name')
 

--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -478,7 +478,7 @@ def scheduler(broker=None):
         broker = get_broker()
     db.close_old_connections()
     try:
-        for s in Schedule.objects.exclude(repeats=0).filter(next_run__lt=timezone.now()):
+        for s in Schedule.objects.exclude(repeats=0).filter(broker_name=broker.list_key, next_run__lt=timezone.now()):
             args = ()
             kwargs = {}
             # get args, kwargs and hook

--- a/django_q/migrations/0008_add_broker_schedule.py
+++ b/django_q/migrations/0008_add_broker_schedule.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_q', '0007_ormq'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='schedule',
+            name='broker_name',
+            field=models.CharField(max_length=100),
+        ),
+    ]

--- a/django_q/models.py
+++ b/django_q/models.py
@@ -7,6 +7,7 @@ from picklefield import PickledObjectField
 from picklefield.fields import dbsafe_decode
 
 from django_q.signing import SignedPackage
+from django_q.conf import Conf
 
 
 class Task(models.Model):
@@ -122,6 +123,7 @@ class Failure(Task):
 
 class Schedule(models.Model):
     name = models.CharField(max_length=100, null=True)
+    broker_name = models.CharField(max_length=100, default=Conf.PREFIX)
     func = models.CharField(max_length=256, help_text='e.g. module.tasks.function')
     hook = models.CharField(max_length=256, null=True, blank=True, help_text='e.g. module.tasks.result_function')
     args = models.TextField(null=True, blank=True, help_text=_("e.g. 1, 2, 'John'"))


### PR DESCRIPTION
When we have several queues, a Schedule object is executed by each queue, but we want once.

Add broker_name field in Schedule model and filter by it in scheduler function removes the problem.
