### PR TITLE
allow scheduler to schedule all pending tasks

### DIFF
--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -544,7 +544,8 @@ def scheduler(broker=None):
             # default behavior is to delete a ONCE schedule
             if s.schedule_type == s.ONCE:
                 if s.repeats < 0:
-                    return s.delete()
+                    s.delete()
+                    continue
                 # but not if it has a positive repeats
                 s.repeats = 0
             # save the schedule


### PR DESCRIPTION
Switched the `return` to a continue so that any pending, run-once tasks can be sent to the broker in one shot.

This is particularly handy if there's a large amount of run-once tasks that are scheduled in the past and need to be caught up.