### PR TITLE
Add option to qinfo to print task IDs

### DIFF
--- a/django_q/management/commands/qinfo.py
+++ b/django_q/management/commands/qinfo.py
@@ -1,7 +1,4 @@
-from optparse import make_option
-
 from django.core.management.base import BaseCommand
-
 from django.utils.translation import ugettext as _
 
 from django_q import VERSION
@@ -13,18 +10,21 @@ class Command(BaseCommand):
     # Translators: help text for qinfo management command
     help = _('General information over all clusters.')
 
-    option_list = BaseCommand.option_list + (
-        make_option('--config',
-                    action='store_true',
-                    dest='config',
-                    default=False,
-                    help='Print current configuration.'),
-        make_option('--ids',
-                    action='store_true',
-                    dest='ids',
-                    default=False,
-                    help='Print cluster task IDs (PIDs).'),
-    )
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--config',
+            action='store_true',
+            dest='config',
+            default=False,
+            help='Print current configuration.',
+        )
+        parser.add_argument(
+            '--ids',
+            action='store_true',
+            dest='ids',
+            default=False,
+            help='Print cluster task ID(s) (PIDs).',
+        )
 
     def handle(self, *args, **options):
         if options.get('ids', True):

--- a/django_q/management/commands/qinfo.py
+++ b/django_q/management/commands/qinfo.py
@@ -6,7 +6,7 @@ from django.utils.translation import ugettext as _
 
 from django_q import VERSION
 from django_q.conf import Conf
-from django_q.monitor import info
+from django_q.monitor import info, get_ids
 
 
 class Command(BaseCommand):
@@ -19,10 +19,17 @@ class Command(BaseCommand):
                     dest='config',
                     default=False,
                     help='Print current configuration.'),
+        make_option('--ids',
+                    action='store_true',
+                    dest='ids',
+                    default=False,
+                    help='Print cluster task IDs (PIDs).'),
     )
 
     def handle(self, *args, **options):
-        if options.get('config', False):
+        if options.get('ids', True):
+            get_ids()
+        elif options.get('config', False):
             hide = ['conf', 'IDLE', 'STOPPING', 'STARTING', 'WORKING', 'SIGNAL_NAMES', 'STOPPED']
             settings = [a for a in dir(Conf) if not a.startswith('__') and a not in hide]
             self.stdout.write('VERSION: {}'.format('.'.join(str(v) for v in VERSION)))

--- a/django_q/monitor.py
+++ b/django_q/monitor.py
@@ -187,3 +187,14 @@ def info(broker=None):
           term.white('{0:.4f}'.format(exec_time))
           )
     return True
+
+
+def get_ids():
+    # prints id (PID) of running clusters
+    stat = Stat.get_all()
+    if stat:
+        for s in stat:
+            print(s.cluster_id)
+    else:
+        print('No clusters appear to be running.')
+    return True


### PR DESCRIPTION
Adding the option to qinfo to print IDs (PIDs) of running clusters provides an easy way for scripts and process managers to fetch their PID(s).
