### PR TITLE
Guard loop sleep made configurable

### DIFF
--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -208,7 +208,7 @@ class Sentinel(object):
         logger.info(_('Q Cluster-{} running.').format(self.parent_pid))
         scheduler(broker=self.broker)
         counter = 0
-        cycle = 0.5  # guard loop sleep in seconds
+        cycle = Conf.GUARD_CYCLE  # guard loop sleep in seconds
         # Guard loop. Runs at least once
         while not self.stop_event.is_set() or not counter:
             # Check Workers
@@ -228,7 +228,7 @@ class Sentinel(object):
                 self.reincarnate(self.pusher)
             # Call scheduler once a minute (or so)
             counter += cycle
-            if counter == 30 and Conf.SCHEDULER:
+            if counter >= 30 and Conf.SCHEDULER:
                 counter = 0
                 scheduler(broker=self.broker)
             # Save current status

--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -73,6 +73,8 @@ class Conf(object):
 
     # Guard loop sleep in seconds
     GUARD_CYCLE = conf.get('guard_cycle', 0.5)
+    if GUARD_CYCLE <= 0 or GUARD_CYCLE >= 60:
+        raise ValueError('`guard_cycle` must be greater than 0 and less than 60 sec')
 
     # Disable the scheduler
     SCHEDULER = conf.get('scheduler', True)

--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -71,6 +71,9 @@ class Conf(object):
     # Failures are always saved
     SAVE_LIMIT = conf.get('save_limit', 250)
 
+    # Guard loop sleep in seconds
+    GUARD_CYCLE = conf.get('guard_cycle', 0.5)
+
     # Disable the scheduler
     SCHEDULER = conf.get('scheduler', True)
 

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -78,6 +78,11 @@ Limits the amount of successful tasks saved to Django.
  - Defaults to ``250``
  - Failures are always saved.
 
+guard_cycle
+~~~~~~~~~~~
+
+Guard loop sleep in seconds
+
 .. _sync:
 
 sync

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -81,7 +81,7 @@ Limits the amount of successful tasks saved to Django.
 guard_cycle
 ~~~~~~~~~~~
 
-Guard loop sleep in seconds
+Guard loop sleep in seconds, must be greater than 0 and less than 60.
 
 .. _sync:
 


### PR DESCRIPTION
Please, consider making guard loop sleep configurable. For ORM broker, it may be useful to increase the cycle to avoid too often modifications of DB.