### PR TITLE
update python and django versions on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,11 @@ services:
 python:
   - "2.7"
   - "3.4"
+  - "3.5"
+  - "3.6-dev"
 
 env:
-    - DJANGO=1.10rc1
+    - DJANGO=1.10.3
     - DJANGO=1.9.8
     - DJANGO=1.8.14
 


### PR DESCRIPTION
Update travis config:

 - add python 3.5
 - add python 3.6-dev
 - update to latest Django (1.10.3)