### PR TITLE
Close broker connection if unusable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - pip install -q django==$DJANGO
   - pip install -r requirements.txt
   - pip install pytest --upgrade
-  - pip install pytest-django codecov sphinx
+  - pip install pytest-django pytest-mock mock codecov sphinx
   - python setup.py install
 
 script:

--- a/django_q/brokers/__init__.py
+++ b/django_q/brokers/__init__.py
@@ -7,10 +7,20 @@ from django_q.conf import Conf
 
 class Broker(object):
     def __init__(self, list_key=Conf.PREFIX):
-        self.connection = self.get_connection(list_key)
+        self.connection = None
         self.list_key = list_key
         self.cache = self.get_cache()
         self._info = None
+
+    @property
+    def connection(self):
+        if not self._connection:
+            self._connection = self.get_connection(self.list_key)
+        return self._connection
+
+    @connection.setter
+    def connection(self, value):
+        self._connection = value
 
     def enqueue(self, task):
         """
@@ -75,6 +85,21 @@ class Broker(object):
         """
         Checks whether the broker connection is available
         :rtype: bool
+        """
+        pass
+
+    def close(self):
+        """
+        Close the broker connection
+        """
+        try:
+            self._close()
+        finally:
+            self.connection = None
+
+    def _close(self):
+        """
+        Close the underlying broker connection
         """
         pass
 

--- a/django_q/brokers/disque.py
+++ b/django_q/brokers/disque.py
@@ -26,6 +26,10 @@ class Disque(Broker):
     def ping(self):
         return self.connection.execute_command('HELLO')[0] > 0
 
+    def _close(self):
+        if self.connection is not None:
+            self.connection.connection_pool.disconnect()
+
     def delete(self, task_id):
         return self.connection.execute_command('DELJOB {}'.format(task_id))
 

--- a/django_q/brokers/mongo.py
+++ b/django_q/brokers/mongo.py
@@ -44,6 +44,11 @@ class Mongo(Broker):
     def ping(self):
         return self.info is not None
 
+    def _close(self):
+        if self.connection is not None:
+            self.connection.close()
+            self._info = None
+
     def info(self):
         if not self._info:
             self._info = 'MongoDB {}'.format(self.connection.server_info()['version'])

--- a/django_q/brokers/redis_broker.py
+++ b/django_q/brokers/redis_broker.py
@@ -38,7 +38,11 @@ class Redis(Broker):
             raise e
 
     def _close(self):
-        if self.connection is not None:
+        if django_redis and Conf.DJANGO_REDIS:
+            from django.core.cache import caches
+            cache = caches[Conf.DJANGO_REDIS]
+            cache.client.close()
+        elif self.connection is not None:
             self.connection.connection_pool.disconnect()
 
     def info(self):

--- a/django_q/brokers/redis_broker.py
+++ b/django_q/brokers/redis_broker.py
@@ -37,6 +37,10 @@ class Redis(Broker):
             logger.error('Can not connect to Redis server.')
             raise e
 
+    def _close(self):
+        if self.connection is not None:
+            self.connection.connection_pool.disconnect()
+
     def info(self):
         if not self._info:
             info = self.connection.info('server')

--- a/django_q/status.py
+++ b/django_q/status.py
@@ -67,6 +67,7 @@ class Stat(Status):
             self.broker.set_stat(self.key, signing.SignedPackage.dumps(self, True), 3)
         except Exception as e:
             logger.error(e)
+            self.broker.close()
 
     def empty_queues(self):
         return self.done_q_size + self.task_q_size == 0

--- a/django_q/tests/test_brokers.py
+++ b/django_q/tests/test_brokers.py
@@ -21,6 +21,7 @@ def test_broker(monkeypatch):
     broker.acknowledge('test')
     broker.ping()
     broker.info()
+    broker.close()
     # stats
     assert broker.get_stat('test_1') is None
     broker.set_stat('test_1', 'test', 3)
@@ -40,6 +41,9 @@ def test_redis(monkeypatch):
     broker = get_broker()
     assert broker.ping() is True
     assert broker.info() is not None
+    # check close and autoreconnect
+    broker.close()
+    assert broker.ping() is True
     monkeypatch.setattr(Conf, 'REDIS', {'host': '127.0.0.1', 'port': 7799})
     broker = get_broker()
     with pytest.raises(Exception):
@@ -52,6 +56,9 @@ def test_custom(monkeypatch):
     assert broker.ping() is True
     assert broker.info() is not None
     assert broker.__class__.__name__ == 'Redis'
+    # check close and autoreconnect
+    broker.close()
+    assert broker.ping() is True
 
 
 def test_disque(monkeypatch):
@@ -106,6 +113,9 @@ def test_disque(monkeypatch):
     broker.enqueue('test')
     broker.delete_queue()
     assert broker.queue_size() == 0
+    # check close and autoreconnect
+    broker.close()
+    assert broker.ping() is True
     # connection test
     monkeypatch.setattr(Conf, 'DISQUE_NODES', ['127.0.0.1:7798', '127.0.0.1:7799'])
     with pytest.raises(redis.exceptions.ConnectionError):
@@ -166,6 +176,9 @@ def test_ironmq(monkeypatch):
     broker.purge_queue()
     assert broker.dequeue() is None
     broker.delete_queue()
+    # check close and autoreconnect
+    broker.close()
+    assert broker.ping() is True
 
 
 @pytest.mark.skipif(not os.getenv('AWS_ACCESS_KEY_ID'),
@@ -220,6 +233,9 @@ def test_sqs(monkeypatch):
     broker.enqueue('test')
     broker.purge_queue()
     broker.delete_queue()
+    # check close and autoreconnect
+    broker.close()
+    assert broker.ping() is True
 
 
 @pytest.mark.django_db
@@ -277,6 +293,9 @@ def test_orm(monkeypatch):
     broker.enqueue('test')
     broker.delete_queue()
     assert broker.queue_size() == 0
+    # check close and autoreconnect
+    broker.close()
+    assert broker.ping() is True
 
 
 @pytest.mark.django_db
@@ -336,3 +355,6 @@ def test_mongo(monkeypatch):
     broker.purge_queue()
     broker.delete_queue()
     assert broker.queue_size() == 0
+    # check close and autoreconnect
+    broker.close()
+    assert broker.ping() is True

--- a/django_q/tests/test_cluster.py
+++ b/django_q/tests/test_cluster.py
@@ -337,6 +337,19 @@ def test_bad_secret(broker, monkeypatch):
 
 
 @pytest.mark.django_db
+def test_bad_broker(broker, mocker):
+    mocker.patch.object(broker, 'set_stat',
+        side_effect=Exception('Unusable connection'))
+    stop_event = Event()
+    stop_event.set()
+    start_event = Event()
+    s = Sentinel(stop_event, start_event, broker=broker, start=False)
+    mock_close = mocker.patch.object(broker, 'close')
+    Stat(s).save()
+    assert mock_close.called
+
+
+@pytest.mark.django_db
 def test_update_failed(broker):
     tag = uuid()
     task = {'id': tag[1],

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=django_q.tests.settings
+mock_use_standalone_module = true

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     description='A multiprocessing distributed task queue for Django',
     long_description=README,
     install_requires=['django>=1.7', 'django-picklefield', 'blessed', 'arrow', 'future'],
-    test_requires=['pytest', 'pytest-django', ],
+    tests_require=['pytest', 'pytest-django', 'pytest-mock', 'mock'],
     cmdclass={'test': PyTest},
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
If the broker is not usable the guard loop can enter a infinite loop
where it tries to save the status every 0.5 seconds. This change forces
the broker connection to reset for those that support it.