### PR TITLE
Replace global Conf mangling with monkeypatch

### DIFF
--- a/django_q/tests/test_admin.py
+++ b/django_q/tests/test_admin.py
@@ -11,8 +11,8 @@ from django_q.signing import SignedPackage
 
 
 @pytest.mark.django_db
-def test_admin_views(admin_client):
-    Conf.ORM = 'default'
+def test_admin_views(admin_client, monkeypatch):
+    monkeypatch.setattr(Conf, 'ORM', 'default')
     s = schedule('schedule.test')
     tag = uuid()
     f = Task.objects.create(
@@ -78,5 +78,3 @@ def test_admin_views(admin_client):
     data = {'post': 'yes'}
     response = admin_client.post(url, data)
     assert response.status_code == 302
-    # cleanup
-    Conf.ORM = None

--- a/django_q/tests/test_brokers.py
+++ b/django_q/tests/test_brokers.py
@@ -9,7 +9,7 @@ from django_q.conf import Conf
 from django_q.humanhash import uuid
 
 
-def test_broker():
+def test_broker(monkeypatch):
     broker = Broker()
     broker.enqueue('test')
     broker.dequeue()
@@ -27,39 +27,35 @@ def test_broker():
     assert broker.get_stat('test_1') == 'test'
     assert broker.get_stats('test:*')[0] == 'test'
     # stats with no cache
-    Conf.CACHE = 'not_configured'
+    monkeypatch.setattr(Conf, 'CACHE', 'not_configured')
     broker.cache = broker.get_cache()
     assert broker.get_stat('test_1') is None
     broker.set_stat('test_1', 'test', 3)
     assert broker.get_stat('test_1') is None
     assert broker.get_stats('test:*') is None
-    Conf.CACHE = 'default'
 
 
-def test_redis():
-    Conf.DJANGO_REDIS = None
+def test_redis(monkeypatch):
+    monkeypatch.setattr(Conf, 'DJANGO_REDIS', None)
     broker = get_broker()
     assert broker.ping() is True
     assert broker.info() is not None
-    Conf.REDIS = {'host': '127.0.0.1', 'port': 7799}
+    monkeypatch.setattr(Conf, 'REDIS', {'host': '127.0.0.1', 'port': 7799})
     broker = get_broker()
     with pytest.raises(Exception):
         broker.ping()
-    Conf.REDIS = None
-    Conf.DJANGO_REDIS = 'default'
 
 
-def test_custom():
-    Conf.BROKER_CLASS = 'brokers.redis_broker.Redis'
+def test_custom(monkeypatch):
+    monkeypatch.setattr(Conf, 'BROKER_CLASS', 'brokers.redis_broker.Redis')
     broker = get_broker()
     assert broker.ping() is True
     assert broker.info() is not None
     assert broker.__class__.__name__ == 'Redis'
-    Conf.BROKER_CLASS = None
 
 
-def test_disque():
-    Conf.DISQUE_NODES = ['127.0.0.1:7711']
+def test_disque(monkeypatch):
+    monkeypatch.setattr(Conf, 'DISQUE_NODES', ['127.0.0.1:7711'])
     # check broker
     broker = get_broker(list_key='disque_test')
     assert broker.ping() is True
@@ -75,7 +71,7 @@ def test_disque():
     broker.acknowledge(task[0])
     assert broker.queue_size() == 0
     # Retry test
-    Conf.RETRY = 1
+    monkeypatch.setattr(Conf, 'RETRY', 1)
     broker.enqueue('test')
     assert broker.queue_size() == 1
     broker.dequeue()
@@ -97,8 +93,8 @@ def test_disque():
     # bulk test
     for i in range(5):
         broker.enqueue('test')
-    Conf.BULK = 5
-    Conf.DISQUE_FASTACK = True
+    monkeypatch.setattr(Conf, 'BULK', 5)
+    monkeypatch.setattr(Conf, 'DISQUE_FASTACK', True)
     tasks = broker.dequeue()
     for task in tasks:
         assert task is not None
@@ -111,21 +107,16 @@ def test_disque():
     broker.delete_queue()
     assert broker.queue_size() == 0
     # connection test
-    Conf.DISQUE_NODES = ['127.0.0.1:7798', '127.0.0.1:7799']
+    monkeypatch.setattr(Conf, 'DISQUE_NODES', ['127.0.0.1:7798', '127.0.0.1:7799'])
     with pytest.raises(redis.exceptions.ConnectionError):
         broker.get_connection()
-    # back to django-redis
-    Conf.DISQUE_NODES = None
-    Conf.DISQUE_FASTACK = False
 
 
 @pytest.mark.skipif(not os.getenv('IRON_MQ_TOKEN'),
                     reason="requires IronMQ credentials")
-def test_ironmq():
-    Conf.DISQUE_NODES = None
-    Conf.SQS = None
-    Conf.IRON_MQ = {'token': os.getenv('IRON_MQ_TOKEN'),
-                    'project_id': os.getenv('IRON_MQ_PROJECT_ID')}
+def test_ironmq(monkeypatch):
+    monkeypatch.setattr(Conf, 'IRON_MQ', {'token': os.getenv('IRON_MQ_TOKEN'),
+                                          'project_id': os.getenv('IRON_MQ_PROJECT_ID')})
     # check broker
     broker = get_broker(list_key=uuid()[0])
     assert broker.ping() is True
@@ -143,7 +134,7 @@ def test_ironmq():
     broker.acknowledge(task[0])
     assert broker.dequeue() is None
     # Retry test
-    # Conf.RETRY = 1
+    # monkeypatch.setattr(Conf, 'RETRY', 1)
     # broker.enqueue('test')
     # assert broker.dequeue() is not None
     # sleep(3)
@@ -162,7 +153,7 @@ def test_ironmq():
     # bulk test
     for i in range(5):
         broker.enqueue('test')
-    Conf.BULK = 5
+    monkeypatch.setattr(Conf, 'BULK', 5)
     tasks = broker.dequeue()
     for task in tasks:
         assert task is not None
@@ -175,19 +166,14 @@ def test_ironmq():
     broker.purge_queue()
     assert broker.dequeue() is None
     broker.delete_queue()
-    # back to django-redis
-    Conf.IRON_MQ = None
-    Conf.DJANGO_REDIS = 'default'
 
 
 @pytest.mark.skipif(not os.getenv('AWS_ACCESS_KEY_ID'),
                     reason="requires AWS credentials")
-def test_sqs():
-    Conf.IRON_MQ = None
-    Conf.DISQUE_NODES = None
-    Conf.SQS = {'aws_region': os.getenv('AWS_REGION'),
-                'aws_access_key_id': os.getenv('AWS_ACCESS_KEY_ID'),
-                'aws_secret_access_key': os.getenv('AWS_SECRET_ACCESS_KEY')}
+def test_sqs(monkeypatch):
+    monkeypatch.setattr(Conf, 'SQS', {'aws_region': os.getenv('AWS_REGION'),
+                                      'aws_access_key_id': os.getenv('AWS_ACCESS_KEY_ID'),
+                                      'aws_secret_access_key': os.getenv('AWS_SECRET_ACCESS_KEY')})
     # check broker
     broker = get_broker(list_key=uuid()[0])
     assert broker.ping() is True
@@ -201,7 +187,7 @@ def test_sqs():
     broker.acknowledge(task[0])
     assert broker.dequeue() is None
     # Retry test
-    Conf.RETRY = 1
+    monkeypatch.setattr(Conf, 'RETRY', 1)
     broker.enqueue('test')
     assert broker.dequeue() is not None
     sleep(2)
@@ -222,7 +208,7 @@ def test_sqs():
     # bulk test
     for i in range(10):
         broker.enqueue('test')
-    Conf.BULK = 12
+    monkeypatch.setattr(Conf, 'BULK', 12)
     tasks = broker.dequeue()
     for task in tasks:
         assert task is not None
@@ -234,15 +220,11 @@ def test_sqs():
     broker.enqueue('test')
     broker.purge_queue()
     broker.delete_queue()
-    # back to django-redis
-    Conf.SQS = None
-    Conf.BULK = 1
-    Conf.DJANGO_REDIS = 'default'
 
 
 @pytest.mark.django_db
-def test_orm():
-    Conf.ORM = 'default'
+def test_orm(monkeypatch):
+    monkeypatch.setattr(Conf, 'ORM', 'default')
     # check broker
     broker = get_broker(list_key='orm_test')
     assert broker.ping() is True
@@ -258,7 +240,7 @@ def test_orm():
     broker.acknowledge(task[0])
     assert broker.queue_size() == 0
     # Retry test
-    Conf.RETRY = 1
+    monkeypatch.setattr(Conf, 'RETRY', 1)
     broker.enqueue('test')
     assert broker.queue_size() == 1
     broker.dequeue()
@@ -280,7 +262,7 @@ def test_orm():
     # bulk test
     for i in range(5):
         broker.enqueue('test')
-    Conf.BULK = 5
+    monkeypatch.setattr(Conf, 'BULK', 5)
     tasks = broker.dequeue()
     assert broker.lock_size() == Conf.BULK
     for task in tasks:
@@ -295,13 +277,11 @@ def test_orm():
     broker.enqueue('test')
     broker.delete_queue()
     assert broker.queue_size() == 0
-    # back to django-redis
-    Conf.ORM = None
 
 
 @pytest.mark.django_db
-def test_mongo():
-    Conf.MONGO = {'host': '127.0.0.1', 'port': 27017}
+def test_mongo(monkeypatch):
+    monkeypatch.setattr(Conf, 'MONGO', {'host': '127.0.0.1', 'port': 27017})
     # check broker
     broker = get_broker(list_key='mongo_test')
     assert broker.ping() is True
@@ -317,7 +297,7 @@ def test_mongo():
     broker.acknowledge(task[0])
     assert broker.queue_size() == 0
     # Retry test
-    Conf.RETRY = 1
+    monkeypatch.setattr(Conf, 'RETRY', 1)
     broker.enqueue('test')
     assert broker.queue_size() == 1
     broker.dequeue()
@@ -356,5 +336,3 @@ def test_mongo():
     broker.purge_queue()
     broker.delete_queue()
     assert broker.queue_size() == 0
-    # back to django-redis
-    Conf.ORM = None

--- a/django_q/tests/test_cached.py
+++ b/django_q/tests/test_cached.py
@@ -10,13 +10,8 @@ from django_q.brokers import get_broker
 
 
 @pytest.fixture
-def broker():
-    Conf.DISQUE_NODES = None
-    Conf.IRON_MQ = None
-    Conf.SQS = None
-    Conf.ORM = None
-    Conf.MONGO = None
-    Conf.DJANGO_REDIS = 'default'
+def broker(monkeypatch):
+    monkeypatch.setattr(Conf, 'DJANGO_REDIS', 'default')
     return get_broker()
 
 
@@ -148,7 +143,7 @@ def test_chain(broker):
 
 
 @pytest.mark.django_db
-def test_async_class(broker):
+def test_async_class(broker, monkeypatch):
     broker.purge_queue()
     broker.cache.clear()
     a = Async('math.copysign')
@@ -186,10 +181,8 @@ def test_async_class(broker):
     assert a.result_group() == [-1]
     assert a.fetch_group() == [a.fetch()]
     # global overrides
-    Conf.SYNC = True
-    Conf.CACHED = True
+    monkeypatch.setattr(Conf, 'SYNC', True)
+    monkeypatch.setattr(Conf, 'CACHED', True)
     a = Async('math.floor', 1.5)
     a.run()
     assert a.result() == 1
-    Conf.SYNC = False
-    Conf.CACHED = False

--- a/django_q/tests/test_monitor.py
+++ b/django_q/tests/test_monitor.py
@@ -9,7 +9,7 @@ from django_q.conf import Conf
 
 
 @pytest.mark.django_db
-def test_monitor():
+def test_monitor(monkeypatch):
     assert Stat.get(0).sentinel == 0
     c = Cluster()
     c.start()
@@ -25,14 +25,13 @@ def test_monitor():
             break
     assert found_c is True
     # test lock size
-    Conf.ORM = 'default'
+    monkeypatch.setattr(Conf, 'ORM', 'default')
     b = get_broker('monitor_test')
     b.enqueue('test')
     b.dequeue()
     assert b.lock_size() == 1
     monitor(run_once=True, broker=b)
     b.delete_queue()
-    Conf.ORM = None
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
The test suite, especially for the brokers, was heavily dependant on the
success of the tests preceeding it to pass. This commit should eliminate
that dependency and allow tests to fail without affecting others.
It also removes the need to cleanup globals manually after a test.