### PR TITLE
Option to undaemonize workers and allows them to spawn child processes

### DIFF
--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -147,7 +147,7 @@ class Sentinel(object):
         p = Process(target=target, args=args)
         p.daemon = True
         if target == worker:
-            p.daemon = False
+            p.daemon = Conf.DAEMINIZE_WORKER
             p.timer = args[2]
             self.pool.append(p)
         p.start()

--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -147,6 +147,7 @@ class Sentinel(object):
         p = Process(target=target, args=args)
         p.daemon = True
         if target == worker:
+            p.daemon = False
             p.timer = args[2]
             self.pool.append(p)
         p.start()

--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -147,7 +147,7 @@ class Sentinel(object):
         p = Process(target=target, args=args)
         p.daemon = True
         if target == worker:
-            p.daemon = Conf.DAEMINIZE_WORKER
+            p.daemon = Conf.DAEMONIZE_WORKERS
             p.timer = args[2]
             self.pool.append(p)
         p.start()

--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -91,6 +91,9 @@ class Conf(object):
                 # sensible default
                 WORKERS = 4
 
+    # Option to undaemonize the workers and allow them to spawn child processes
+    DAEMONIZE_WORKERS = conf.get('daemonize_workers', True)
+
     # Maximum number of tasks that each cluster can work on
     QUEUE_LIMIT = conf.get('queue_limit', int(WORKERS) ** 2)
 

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -40,6 +40,12 @@ workers
 
 The number of workers to use in the cluster. Defaults to CPU count of the current host, but can be set to a custom number.  [#f1]_
 
+daemonize_workers
+~~~~~~~~~~~~~~~~~
+
+Set the daemon flag when spawning workers. You may need to disable this flag if your worker needs to spawn child process but be carefull with orphaned child processes in case of sudden termination of the main process.
+Defaults to ``True``.
+
 recycle
 ~~~~~~~
 


### PR DESCRIPTION
Following discussion https://github.com/Koed00/django-q/issues/211

I added an option to undaemonize the workers thus allowing them to spawn child processes.
That could lead to orphaned child processes in case of crash of the main process. But in some use cases this is necessary.

Feel free to integrate or reject this pull request.

Cheers,
Yann.