### PR TITLE
Remove unused dependency `future`

### DIFF
--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -6,10 +6,6 @@ from __future__ import unicode_literals
 
 from builtins import range
 
-from future import standard_library
-
-standard_library.install_aliases()
-
 # Standard
 import importlib
 import signal

--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -4,8 +4,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from builtins import range
-
 # Standard
 import importlib
 import signal
@@ -26,11 +24,13 @@ from django import db
 import signing
 import tasks
 
+from django_q.compat import range
 from django_q.conf import Conf, logger, psutil, get_ppid, rollbar
 from django_q.models import Task, Success, Schedule
 from django_q.status import Stat, Status
 from django_q.brokers import get_broker
 from django_q.signals import pre_execute
+
 
 
 class Cluster(object):

--- a/django_q/compat.py
+++ b/django_q/compat.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+"""
+Compatibility layer.
+
+Intentionally replaces use of python-future
+"""
+
+# https://github.com/Koed00/django-q/issues/4
+
+try:
+    range = xrange
+except NameError:
+    range = range
+

--- a/django_q/tests/test_brokers.py
+++ b/django_q/tests/test_brokers.py
@@ -5,6 +5,7 @@ import pytest
 import redis
 
 from django_q.brokers import get_broker, Broker
+from django_q.compat import range
 from django_q.conf import Conf
 from django_q.humanhash import uuid
 

--- a/django_q/tests/test_cached.py
+++ b/django_q/tests/test_cached.py
@@ -3,6 +3,7 @@ from multiprocessing import Event, Queue, Value
 import pytest
 
 from django_q.cluster import pusher, worker, monitor
+from django_q.compat import range
 from django_q.conf import Conf
 from django_q.tasks import async, result, fetch, count_group, result_group, fetch_group, delete_group, delete_cached, \
     async_iter, Chain, async_chain, Iter, Async

--- a/django_q/tests/test_cluster.py
+++ b/django_q/tests/test_cluster.py
@@ -11,6 +11,7 @@ myPath = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, myPath + '/../')
 
 from django_q.cluster import Cluster, Sentinel, pusher, worker, monitor, save_task
+from django_q.compat import range
 from django_q.humanhash import DEFAULT_WORDLIST, uuid
 from django_q.tasks import fetch, fetch_group, async, result, result_group, count_group, delete_group, queue_size
 from django_q.models import Task, Success

--- a/django_q/tests/test_monitor.py
+++ b/django_q/tests/test_monitor.py
@@ -3,6 +3,7 @@ import pytest
 from django_q.tasks import async
 from django_q.brokers import get_broker
 from django_q.cluster import Cluster
+from django_q.compat import range
 from django_q.monitor import monitor, info
 from django_q.status import Stat
 from django_q.conf import Conf

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,6 @@
 arrow
 blessed
 django-picklefield
-future
 hiredis
 redis
 psutil

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     license='MIT',
     description='A multiprocessing distributed task queue for Django',
     long_description=README,
-    install_requires=['django>=1.8', 'django-picklefield', 'blessed', 'arrow', 'future'],
+    install_requires=['django>=1.8', 'django-picklefield', 'blessed', 'arrow'],
     test_requires=['pytest', 'pytest-django', ],
     cmdclass={'test': PyTest},
     classifiers=[


### PR DESCRIPTION
The use of `future` is causing problems because we are bundling dependencies statically for a distribution that targets py2+py3.

It was introduced because of #4 in PR #5

Hard to believe that someone would bundle dependencies, but in our case it's very relevant because we distribute python packages for net-less installation with everything bundled in. We can't use django-q for our packages because `future` is raising exceptions when loaded on Python 3:

https://github.com/learningequality/kolibri/issues/1797

Anyways, it wasn't used in more than 1 single instance of `from builtins import range`.

Here are some other advantages:

 * `future` redefines and monkey patches sys.modules for all other packages, perhaps not nice!
 * It has 106 unsolved issues
 * Removes a dependency, so makes everything nicer :)
 * `future` was missing in README.rst description

I've fixed some more cases where `range` wasn't loaded in a backwards compatible way. You can say that even though `future` was added as a dependency, it wasn't used in a couple of cases where it should have (test code).

## Reference

There was only one case of accessing something redefined by `futures` library.

```ack-grep --python 'copyreg'
ack-grep --python 'import.*queue'
ack-grep --python 'reprlib'
ack-grep --python 'socketserver'
ack-grep --python 'winreg'
ack-grep --python 'test.support'
ack-grep --python 'import.*html'
ack-grep --python 'html.parser'
ack-grep --python 'html.entites'
ack-grep --python 'import.*http'
ack-grep --python 'http.client'
ack-grep --python 'http.server'
ack-grep --python 'http.cookies'
ack-grep --python 'http.cookiejar'
ack-grep --python 'urllib.parse'
ack-grep --python 'urllib.request'
ack-grep --python 'urllib.response'
ack-grep --python 'urllib.error'
ack-grep --python 'urllib.robotparser'
ack-grep --python 'xmlrpc.client'
ack-grep --python 'xmlrpc.server'
ack-grep --python '_thread'
ack-grep --python '_dummy_thread'
ack-grep --python '_markupbase'
ack-grep --python 'itertools.*filterfalse'
ack-grep --python 'itertools.*zip_longest'
ack-grep --python 'sys.*intern'
ack-grep --python 'collections.*UserDict'
ack-grep --python 'collections.*UserList'
ack-grep --python 'collections.*UserString'
ack-grep --python 'collections.*OrderedDict'
ack-grep --python 'collections.*Counter'
ack-grep --python 'subprocess.*'
ack-grep --python 'subprocess.*getoutput'
ack-grep --python 'subprocess.*getstatusoutput'
ack-grep --python 'subprocess.*check_output'

cluster.py
7:from builtins import range 
```