### PR TITLE
Use 32 bits integer for repeat field to avoid overflow with frequent scheduled tasks

### DIFF
--- a/django_q/migrations/0009_auto_20171009_0915.py
+++ b/django_q/migrations/0009_auto_20171009_0915.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_q', '0008_auto_20160224_1026'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='schedule',
+            name='repeats',
+            field=models.IntegerField(default=-1, help_text='n = n times, -1 = forever', verbose_name='Repeats'),
+        ),
+    ]

--- a/django_q/models.py
+++ b/django_q/models.py
@@ -147,7 +147,7 @@ class Schedule(models.Model):
     schedule_type = models.CharField(max_length=1, choices=TYPE, default=TYPE[0][0], verbose_name=_('Schedule Type'))
     minutes = models.PositiveSmallIntegerField(null=True, blank=True,
                                                help_text=_('Number of minutes for the Minutes type'))
-    repeats = models.SmallIntegerField(default=-1, verbose_name=_('Repeats'), help_text=_('n = n times, -1 = forever'))
+    repeats = models.IntegerField(default=-1, verbose_name=_('Repeats'), help_text=_('n = n times, -1 = forever'))
     next_run = models.DateTimeField(verbose_name=_('Next Run'), default=timezone.now, null=True)
     task = models.CharField(max_length=100, null=True, editable=False)
 


### PR DESCRIPTION
Simple field migration as discussed in #255 