### PR TITLE
Django 2.0 compatibility

### DIFF
--- a/django_q/__init__.py
+++ b/django_q/__init__.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from django import get_version
+import django
 
 myPath = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, myPath)
@@ -11,8 +11,7 @@ default_app_config = 'django_q.apps.DjangoQConfig'
 
 # root imports will slowly be deprecated.
 # please import from the relevant sub modules
-split_version = get_version().split('.')
-if split_version[1] not in ('9', '10', '11'):
+if django.VERSION[:2] < (1, 9):
     from .tasks import async, schedule, result, result_group, fetch, fetch_group, count_group, delete_group, queue_size
     from .models import Task, Schedule, Success, Failure
     from .cluster import Cluster

--- a/django_q/models.py
+++ b/django_q/models.py
@@ -1,5 +1,8 @@
 from django import get_version
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError: # Django < 1.10
+    from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.db import models
 from django.utils import timezone

--- a/django_q/tests/test_admin.py
+++ b/django_q/tests/test_admin.py
@@ -1,6 +1,9 @@
-from django.core.urlresolvers import reverse
-
+try:
+    from django.urls import reverse
+except ImportError: # Django < 1.10
+    from django.core.urlresolvers import reverse
 from django.utils import timezone
+
 import pytest
 
 from django_q.tasks import schedule


### PR DESCRIPTION
Just some simple fixes for Django 2.0 compatibility: 

- django.core.urlresolvers -> django.urls
- fix major/minor version detection

Might be other issues, but if there are I haven't come across them so far.