### PR TITLE
Allow SQS to use environment variables

### DIFF
--- a/django_q/brokers/aws_sqs.py
+++ b/django_q/brokers/aws_sqs.py
@@ -51,9 +51,12 @@ class Sqs(Broker):
 
     @staticmethod
     def get_connection(list_key=Conf.PREFIX):
-        return Session(aws_access_key_id=Conf.SQS['aws_access_key_id'],
-                       aws_secret_access_key=Conf.SQS['aws_secret_access_key'],
-                       region_name=Conf.SQS['aws_region'])
+        config = Conf.SQS
+        if 'aws_region' in config:
+            config['region_name'] = config['aws_region']
+            del(config['aws_region'])
+        return Session(**config)
+
 
     def get_queue(self):
         self.sqs = self.connection.resource('sqs')

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -229,7 +229,7 @@ All connection keywords are supported. See the `iron-mq <https://github.com/iron
 
 sqs
 ~~~
-To use Amazon SQS as a broker you need to provide the AWS region and credentials::
+To use Amazon SQS as a broker you need to provide the AWS region and credentials either via the config, or any other boto3 configuration method::
 
     # example SQS broker connection
 
@@ -241,9 +241,9 @@ To use Amazon SQS as a broker you need to provide the AWS region and credentials
         'queue_limit': 100,
         'bulk': 5,
         'sqs': {
-            'aws_region': 'us-east-1',
-            'aws_access_key_id': 'ac-Idr.....YwflZBaaxI',
-            'aws_secret_access_key': '500f7b....b0f302e9'
+            'aws_region': 'us-east-1',  # optional
+            'aws_access_key_id': 'ac-Idr.....YwflZBaaxI',  # optional
+            'aws_secret_access_key': '500f7b....b0f302e9'  # optional
         }
     }
 


### PR DESCRIPTION
If no credentials are set, boto3 will look them up in the environment variables, boto3 config or aws config by default. This PR makes the credentials in the config optional, so boto3 can check the other locations if needed.