### PR TITLE
Document the behaviour of retry value properly

### DIFF
--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -57,6 +57,8 @@ timeout
 """""""
 Overrides the cluster's timeout setting for this task.
 
+See :ref:`retry` for details how to set values for timeout.
+
 ack_failure
 """""""""""
 Overrides the cluster's :ref:`ack_failures` setting for this task.


### PR DESCRIPTION
This issue has been reported many times in Django-Q's issue tracker:
https://github.com/Koed00/django-q/issues/183
https://github.com/Koed00/django-q/issues/180
https://github.com/Koed00/django-q/issues/307

All these issue have been closed and responses have noted that retry should
be set bigger than timeout or duration of any task.