### PR TITLE
Improve Unit tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,13 +211,13 @@ python -m venv .venv
 
 
 # Run required services (you need to have docker-compose installed)
-docker-compose -f test-services-docker-compose.yaml up -d
+docker-compose --project-name django-q -f test-services-docker-compose.yaml up -d
 
 # Run tests
 .venv/bin/pytest
 
 # Stop the services required by tests (when you no longer plan to run tests)
-docker-compose -f test-services-docker-compose.yaml down
+docker-compose --project-name django-q -f test-services-docker-compose.yaml down
 
 ```
 

--- a/README.rst
+++ b/README.rst
@@ -198,23 +198,23 @@ The following commands can be used to run the tests:
 
 ```
 # Create virtual environment
-python -m venv venv
+python -m venv .venv
 
 # Install requirements
-venv/bin/pip install -r requirements.txt
+.venv/bin/pip install -r requirements.txt
 
 # Install test dependencies
-venv/bin/pip install pytest pytest-django
+.venv/bin/pip install pytest pytest-django
 
 # Install django-q
-venv/bin/python setup.py develop
+.venv/bin/python setup.py develop
 
 
 # Run required services (you need to have docker-compose installed)
 docker-compose -f test-services-docker-compose.yaml up -d
 
 # Run tests
-venv/bin/pytest
+.venv/bin/pytest
 
 # Stop the services required by tests (when you no longer plan to run tests)
 docker-compose -f test-services-docker-compose.yaml down

--- a/django_q/tests/conftest.py
+++ b/django_q/tests/conftest.py
@@ -1,0 +1,109 @@
+import contextlib
+import os
+import re
+import subprocess
+
+import pytest
+
+
+@pytest.fixture
+def ironmq_config():
+    token = os.getenv('IRON_MQ_TOKEN')
+    project_id = os.getenv('IRON_MQ_PROJECT_ID')
+    if token and project_id:
+        yield {'token': token,
+               'project_id': project_id}
+
+    elif _is_ironmq_running_locally():
+        with _temp_ironmq_project() as (user_token, project_id):
+            yield {'token': user_token,
+                   'project_id': project_id,
+                   'host': 'localhost',
+                   'port': 8080,
+                   'protocol': 'http'}
+
+    else:
+        pytest.skip("Requires IronMQ credentials or running IronMQ locally")
+
+
+def _is_ironmq_running_locally():
+    try:
+        p = subprocess.run(
+            # This assumes that IronMQ is running in a Docker container started with command
+            # docker-compose --project-name django-q -f test-services-docker-compose.yaml up
+            ('docker', 'ps', '-q', '-f', 'name=django-q_ironmq_1'),
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+
+        return bool(p.stdout.strip())
+
+    except FileNotFoundError:
+        # docker command not available
+        return False
+
+
+@contextlib.contextmanager
+def _temp_ironmq_project():
+    # Just make sure the user does not exist due to earlier run
+    _run_auth_cli('delete', 'user', 'ironmq@example.org')
+
+    p = _run_auth_cli(
+        'create',
+        'user',
+        'ironmq@example.org',
+        'password',
+    )
+    assert p.returncode == 0, 'Failed to create user in IronMQ: {}'.format(p.stdout)
+
+    m = re.match(
+        r'.*msg="user created successfully".*id=(?P<id>[0-9a-f]+)\s.*token=(?P<token>[^\s]+).*',
+        p.stdout.strip(),
+    )
+    assert m, 'Unexpected user created message: {}'.format(p.stdout)
+
+    user_id = m.group('id')
+    user_token = m.group('token')
+    if not user_id or not user_token:
+        pytest.skip('No IronMQ credentials provided and IronMQ not running locally.')
+
+    p = _run_auth_cli(
+        '-t', user_token,
+        'create',
+        'project',
+        'django-q-test',
+    )
+    assert p.returncode == 0, 'Failed to create IronMQ project: {}'.format(p.stdout)
+
+    m = re.match(
+        r'.*msg="project created successfully".*id=(?P<id>[0-9a-f]+)\s.*',
+        p.stdout.strip(),
+    )
+    assert m, 'Unexpected project created message: {}'.format(p.stdout)
+
+    project_id = m.group('id')
+
+    yield user_token, project_id
+
+    p = _run_auth_cli('delete', 'user', user_id)
+    assert p.returncode == 0, 'Failed to remove user from IronMQ: {}'.format(p.stdout)
+
+
+def _run_auth_cli(*args):
+    return subprocess.run(
+        (
+            'docker',
+            'run',
+            '--network', 'django-q_test',
+            'iron/authcli',
+            'iron',
+            '-h', 'http://ironauth:8090',
+            '-t', 'adminToken',
+            *args,
+        ),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+    )

--- a/django_q/tests/test_brokers.py
+++ b/django_q/tests/test_brokers.py
@@ -112,11 +112,9 @@ def test_disque(monkeypatch):
         broker.get_connection()
 
 
-@pytest.mark.skipif(not os.getenv('IRON_MQ_TOKEN'),
-                    reason="requires IronMQ credentials")
-def test_ironmq(monkeypatch):
-    monkeypatch.setattr(Conf, 'IRON_MQ', {'token': os.getenv('IRON_MQ_TOKEN'),
-                                          'project_id': os.getenv('IRON_MQ_PROJECT_ID')})
+def test_ironmq(ironmq_config, monkeypatch):
+    monkeypatch.setattr(Conf, 'IRON_MQ', ironmq_config)
+
     # check broker
     broker = get_broker(list_key=uuid()[0])
     assert broker.ping() is True

--- a/test-services-docker-compose.yaml
+++ b/test-services-docker-compose.yaml
@@ -1,5 +1,9 @@
 version: '2.2'
 
+networks:
+  test:
+    driver: bridge
+
 services:
   disque:
     image: efrecon/disque:1.0-rc1
@@ -15,3 +19,17 @@ services:
     image: mongo:4
     ports:
       - '27017:27017/tcp'
+
+  ironmq:
+    image: iron/mq:latest
+    networks:
+      - test
+    ports:
+      - '8080:8080/tcp'
+    volumes:
+      - ./test_iron_mq_config.json:/ironmq/ironmq/config.json
+
+  ironauth:
+    image: iron/auth:latest
+    networks:
+      - test

--- a/test_iron_mq_config.json
+++ b/test_iron_mq_config.json
@@ -1,0 +1,45 @@
+{
+  "license": {
+    "description": "This is your license key provided by Iron.io",
+    "key": "abcdef123456"
+  },
+  "api": {
+    "http_port": 8080
+  },
+  "auth": {
+    "host": "http://ironauth:8090"
+  },
+  "logging": {
+    "to": "",
+    "level": "info",
+    "prefix": ""
+  },
+  "push" : {
+    "api_host": "http://localhost:8080",
+    "base_url": "http://localhost:8080",
+    "auth_token":"adminToken"
+  },
+  "data": {
+    "aes_key_description": "Key for generating id's.",
+    "aes_key": "770A8A65DA156D24EE2A093277530142",
+    "dir_description": "Where data files will be stored",
+    "dir": "../data",
+    "cache_size_description": "Size of cache in MB -- don't get carried away",
+    "cache_size": 128
+  },
+  "stats": {
+    "interval":0,
+    "DataDog" : {
+      "target": "",
+      "threshold":0
+    },
+    "NewRelic" : {
+        "license_key" : ""
+    },
+    "stathat":{
+      "email":"",
+      "prefix":""
+    },
+    "Log15":[]
+  }
+}


### PR DESCRIPTION
The changes in this PR update the unit test documentation to use _.venv_ directory for Python virtual environment as that directory is ignored via _.gitignore_ and enables IronMQ unit tests to be run easily without any extra configuration.

The current way for providing IronMQ user token and project ID is still supported but that could be removed. The original way to configure IronMQ was left in the tests as the new way requires you to have Docker installed.