### PR TITLE
Fix scheduler concurrency with multiple clusters

### DIFF
--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -203,7 +203,6 @@ class Sentinel(object):
         self.start_event.set()
         Stat(self).save()
         logger.info(_('Q Cluster-{} running.').format(self.parent_pid))
-        scheduler(broker=self.broker)
         counter = 0
         cycle = Conf.GUARD_CYCLE  # guard loop sleep in seconds
         # Guard loop. Runs at least once

--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -491,70 +491,69 @@ def scheduler(broker=None):
         broker = get_broker()
     db.close_old_connections()
     try:
-        for s in Schedule.objects.exclude(repeats=0).filter(next_run__lt=timezone.now()):
-            args = ()
-            kwargs = {}
-            # get args, kwargs and hook
-            if s.kwargs:
-                try:
-                    # eval should be safe here because dict()
-                    kwargs = eval('dict({})'.format(s.kwargs))
-                except SyntaxError:
-                    kwargs = {}
-            if s.args:
-                args = ast.literal_eval(s.args)
-                # single value won't eval to tuple, so:
-                if type(args) != tuple:
-                    args = (args,)
-            q_options = kwargs.get('q_options', {})
-            if s.hook:
-                q_options['hook'] = s.hook
-            # set up the next run time
-            if not s.schedule_type == s.ONCE:
-                next_run = arrow.get(s.next_run)
-                while True:
-                    if s.schedule_type == s.MINUTES:
-                        next_run = next_run.shift(minutes=+(s.minutes or 1))
-                    elif s.schedule_type == s.HOURLY:
-                        next_run = next_run.shift(hours=+1)
-                    elif s.schedule_type == s.DAILY:
-                        next_run = next_run.shift(days=+1)
-                    elif s.schedule_type == s.WEEKLY:
-                        next_run = next_run.shift(weeks=+1)
-                    elif s.schedule_type == s.MONTHLY:
-                        next_run = next_run.shift(months=+1)
-                    elif s.schedule_type == s.QUARTERLY:
-                        next_run = next_run.shift(months=+3)
-                    elif s.schedule_type == s.YEARLY:
-                        next_run = next_run.shift(years=+1)
-                    if Conf.CATCH_UP or next_run > arrow.utcnow():
-                        break
-                # arrow always returns a tz aware datetime, and we don't want
-                # this when we explicitly configured django with USE_TZ=False
-                s.next_run = next_run.datetime if settings.USE_TZ else next_run.datetime.replace(tzinfo=None)
-                s.repeats += -1
-            # send it to the cluster
-            q_options['broker'] = broker
-            q_options['group'] = q_options.get('group', s.name or s.id)
-            kwargs['q_options'] = q_options
-            s.task = django_q.tasks.async_task(s.func, *args, **kwargs)
-            # log it
-            if not s.task:
-                logger.error(
-                    _('{} failed to create a task from schedule [{}]').format(current_process().name,
-                                                                              s.name or s.id))
-            else:
-                logger.info(
-                    _('{} created a task from schedule [{}]').format(current_process().name, s.name or s.id))
-            # default behavior is to delete a ONCE schedule
-            if s.schedule_type == s.ONCE:
-                if s.repeats < 0:
-                    s.delete()
-                    continue
-                # but not if it has a positive repeats
-                s.repeats = 0
-            # save the schedule
-            s.save()
+        with db.transaction.atomic():
+            for s in Schedule.objects.select_for_update().exclude(repeats=0).filter(next_run__lt=timezone.now()):
+                args = ()
+                kwargs = {}
+                # get args, kwargs and hook
+                if s.kwargs:
+                    try:
+                        # eval should be safe here because dict()
+                        kwargs = eval('dict({})'.format(s.kwargs))
+                    except SyntaxError:
+                        kwargs = {}
+                if s.args:
+                    args = ast.literal_eval(s.args)
+                    # single value won't eval to tuple, so:
+                    if type(args) != tuple:
+                        args = (args,)
+                q_options = kwargs.get('q_options', {})
+                if s.hook:
+                    q_options['hook'] = s.hook
+                # set up the next run time
+                if not s.schedule_type == s.ONCE:
+                    next_run = arrow.get(s.next_run)
+                    while True:
+                        if s.schedule_type == s.MINUTES:
+                            next_run = next_run.shift(minutes=+(s.minutes or 1))
+                        elif s.schedule_type == s.HOURLY:
+                            next_run = next_run.shift(hours=+1)
+                        elif s.schedule_type == s.DAILY:
+                            next_run = next_run.shift(days=+1)
+                        elif s.schedule_type == s.WEEKLY:
+                            next_run = next_run.shift(weeks=+1)
+                        elif s.schedule_type == s.MONTHLY:
+                            next_run = next_run.shift(months=+1)
+                        elif s.schedule_type == s.QUARTERLY:
+                            next_run = next_run.shift(months=+3)
+                        elif s.schedule_type == s.YEARLY:
+                            next_run = next_run.shift(years=+1)
+                        if Conf.CATCH_UP or next_run > arrow.utcnow():
+                            break
+                    s.next_run = next_run.datetime
+                    s.repeats += -1
+                # send it to the cluster
+                q_options['broker'] = broker
+                q_options['group'] = q_options.get('group', s.name or s.id)
+                kwargs['q_options'] = q_options
+                s.task = django_q.tasks.async_task(s.func, *args, **kwargs)
+                # log it
+                if not s.task:
+                    logger.error(
+                        _('{} failed to create a task from schedule [{}]').format(current_process().name,
+                                                                                  s.name or s.id))
+                else:
+                    logger.info(
+                        _('{} created a task from schedule [{}]').format(current_process().name, s.name or s.id))
+                # default behavior is to delete a ONCE schedule
+                if s.schedule_type == s.ONCE:
+                    if s.repeats < 0:
+                        s.delete()
+                        continue
+                    # but not if it has a positive repeats
+                    s.repeats = 0
+                # save the schedule
+                s.save()
     except Exception as e:
         logger.error(e)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,8 +44,8 @@ extensions = [
 ]
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3.5', None),
-                       'django': ('https://docs.djangoproject.com/en/1.8/',
-                                  'https://docs.djangoproject.com/en/1.8//_objects/')}
+                       'django': ('https://docs.djangoproject.com/en/2.2/',
+                                  'https://docs.djangoproject.com/en/2.2/_objects/')}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
This pull request fixes two issues:

- Prevents that the Sentinel is running the [Scheduler](https://github.com/Koed00/django-q/blob/master/django_q/cluster.py#L205) on startup (even when we added `scheduler: False` to the configuration).

- Lock the selected rows with `select_for_update` when creating tasks from Scheduler items. This makes sure that tasks are created only once (fixes #231). I tested this with PostgreSQL and MySQL. 
