### PR TITLE
Fix issue when using USE_TZ=False with MySQL

### DIFF
--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -16,6 +16,7 @@ import socket
 import traceback
 # Django
 from django import db
+from django.conf import settings
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 from multiprocessing import Event, Process, Value, current_process
@@ -529,7 +530,9 @@ def scheduler(broker=None):
                         next_run = next_run.replace(years=+1)
                     if Conf.CATCH_UP or next_run > arrow.utcnow():
                         break
-                s.next_run = next_run.datetime
+                # arrow always returns a tz aware datetime, and we don't want
+                # this when we explicitly configured django with USE_TZ=False
+                s.next_run = next_run.datetime if settings.USE_TZ else next_run.datetime.replace(tzinfo=None)
                 s.repeats += -1
             # send it to the cluster
             q_options['broker'] = broker


### PR DESCRIPTION
arrow always returns a tz aware datetime, and we don't want this when we explicitly configured Django with `USE_TZ=False`. This causes issues with MySQL (`ERROR MySQL backend does not support timezone-aware datetimes when USE_TZ is False.`)

This pull request makes the datetime object from arrow naive again when `USE_TZ=False`.

This fixes #350 and #352 