### PR TITLE
Add 

### DIFF
--- a/.env.tmpl
+++ b/.env.tmpl
@@ -1,0 +1,8 @@
+# *** Supply these to enable Iron MQ test
+# IRON_MQ_TOKEN=
+# IRON_MQ_PROJECT=
+
+# *** Supply these to enable live AWS SQS test
+# AWS_REGION=
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ db.sqlite3
 .idea
 djq
 node_modules
+.env

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,4 @@
+FROM python:3.7-buster
+COPY . /code/
+RUN pip install -r /code/requirements-test.txt; python /code/setup.py develop
+WORKDIR /code

--- a/README.rst
+++ b/README.rst
@@ -188,36 +188,20 @@ Testing
 
 To run the tests you will need the following in addition to install requirements:
 
-* `py.test <http://pytest.org/latest/>`__
-* `pytest-django <https://github.com/pytest-dev/pytest-django>`__
-* disque from https://github.com/antirez/disque.git
-* Redis
-* MongoDB
+* `docker-compose <https://docs.docker.com/compose/>`__
 
 The following commands can be used to run the tests:
 
 .. code:: bash
 
-    # Create virtual environment
-    python -m venv venv
+    # Create .env file, uncomment and supply any desired environment settings
+    cp .env.tmpl .env
 
-    # Install requirements
-    venv/bin/pip install -r requirements.txt
-
-    # Install test dependencies
-    venv/bin/pip install pytest pytest-django
-
-    # Install django-q
-    venv/bin/python setup.py develop
-
-    # Run required services (you need to have docker-compose installed)
-    docker-compose -f test-services-docker-compose.yaml up -d
+    # Build Docker container with services and pytest
+    docker-compose -f test-services-docker-compose.yaml build
 
     # Run tests
-    venv/bin/pytest
-
-    # Stop the services required by tests (when you no longer plan to run tests)
-    docker-compose -f test-services-docker-compose.yaml down
+    docker-compose -f test-services-docker-compose.yaml run djangoq pytest
 
 Locale
 ~~~~~~

--- a/django_q/tests/settings.py
+++ b/django_q/tests/settings.py
@@ -109,7 +109,7 @@ STATIC_URL = '/static/'
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "redis://127.0.0.1:6379/0",
+        "LOCATION": "redis://redis:6379/0",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
             "PARSER_CLASS": "redis.connection.HiredisParser",
@@ -118,8 +118,13 @@ CACHES = {
 }
 
 # Django Q specific
-Q_CLUSTER = {'name': 'django_q_test',
-             'cpu_affinity': 1,
-             'testing': True,
-             'log_level': 'DEBUG',
-             'django_redis': 'default'}
+Q_CLUSTER = {
+    'name': 'django_q_test',
+    'cpu_affinity': 1,
+    'testing': True,
+    'log_level': 'DEBUG',
+    'django_redis': 'default',
+    'redis': {
+        'host': 'redis'
+    }
+}

--- a/django_q/tests/test_brokers.py
+++ b/django_q/tests/test_brokers.py
@@ -209,8 +209,8 @@ def test_sqs_local(monkeypatch):
     # fail
     broker.enqueue('test')
     while task is None:
-        task = broker.dequeue()[0]
-    broker.fail(task[0])
+        task = broker.dequeue()
+    broker.fail(task[0][0])
     # bulk test
     for i in range(10):
         broker.enqueue('test')
@@ -271,8 +271,8 @@ def canceled_sqs(monkeypatch):
     # fail
     broker.enqueue('test')
     while task is None:
-        task = broker.dequeue()[0]
-    broker.fail(task[0])
+        task = broker.dequeue()
+    broker.fail(task[0][0])
     # bulk test
     for i in range(10):
         broker.enqueue('test')

--- a/django_q/tests/test_brokers.py
+++ b/django_q/tests/test_brokers.py
@@ -40,7 +40,7 @@ def test_redis(monkeypatch):
     broker = get_broker()
     assert broker.ping() is True
     assert broker.info() is not None
-    monkeypatch.setattr(Conf, 'REDIS', {'host': '127.0.0.1', 'port': 7799})
+    monkeypatch.setattr(Conf, 'REDIS', {'host': 'redis', 'port': 7799})
     broker = get_broker()
     with pytest.raises(Exception):
         broker.ping()
@@ -55,7 +55,7 @@ def test_custom(monkeypatch):
 
 
 def test_disque(monkeypatch):
-    monkeypatch.setattr(Conf, 'DISQUE_NODES', ['127.0.0.1:7711'])
+    monkeypatch.setattr(Conf, 'DISQUE_NODES', ['disque:7711'])
     # check broker
     broker = get_broker(list_key='disque_test')
     assert broker.ping() is True
@@ -107,7 +107,7 @@ def test_disque(monkeypatch):
     broker.delete_queue()
     assert broker.queue_size() == 0
     # connection test
-    monkeypatch.setattr(Conf, 'DISQUE_NODES', ['127.0.0.1:7798', '127.0.0.1:7799'])
+    monkeypatch.setattr(Conf, 'DISQUE_NODES', ['disque:7798', 'disque:7799'])
     with pytest.raises(redis.exceptions.ConnectionError):
         broker.get_connection()
 
@@ -165,6 +165,66 @@ def test_ironmq(monkeypatch):
     broker.enqueue('test')
     broker.purge_queue()
     assert broker.dequeue() is None
+    broker.delete_queue()
+
+
+def test_sqs_local(monkeypatch):
+    monkeypatch.setattr(Conf, 'SQS', {'aws_region': 'fake-region',
+                                      'aws_sqs_url': 'http://sqs:9324',
+                                      'aws_access_key_id': 'fake-id',
+                                      'aws_secret_access_key': 'fake-key'})
+    broker = get_broker(list_key=uuid()[0])
+    assert broker.ping() is True
+    assert broker.ping() is not None
+    assert broker.queue_size() == 0
+    # async_task
+    broker.enqueue('test')
+    # dequeue
+    task = broker.dequeue()[0]
+    assert task[1] == 'test'
+    broker.acknowledge(task[0])
+    assert broker.dequeue() is None
+    # Retry test
+    monkeypatch.setattr(Conf, 'RETRY', 1)
+    broker.enqueue('test')
+    sleep(2)
+    # Sometimes SQS is not linear
+    task = broker.dequeue()
+    if not task:
+        pytest.skip('SQS being weird')
+    task = task[0]
+    assert len(task) > 0
+    broker.acknowledge(task[0])
+    sleep(2)
+    # delete job
+    monkeypatch.setattr(Conf, 'RETRY', 60)
+    broker.enqueue('test')
+    sleep(1)
+    task = broker.dequeue()
+    if not task:
+        pytest.skip('SQS being weird')
+    task_id = task[0][0]
+    broker.delete(task_id)
+    assert broker.dequeue() is None
+    # fail
+    broker.enqueue('test')
+    while task is None:
+        task = broker.dequeue()[0]
+    broker.fail(task[0])
+    # bulk test
+    for i in range(10):
+        broker.enqueue('test')
+    monkeypatch.setattr(Conf, 'BULK', 12)
+    tasks = broker.dequeue()
+    for task in tasks:
+        assert task is not None
+        broker.acknowledge(task[0])
+    # duplicate acknowledge
+    broker.acknowledge(task[0])
+    assert broker.lock_size() == 0
+    # delete queue
+    broker.enqueue('test')
+    broker.purge_queue()
     broker.delete_queue()
 
 
@@ -289,7 +349,7 @@ def test_orm(monkeypatch):
 
 @pytest.mark.django_db
 def test_mongo(monkeypatch):
-    monkeypatch.setattr(Conf, 'MONGO', {'host': '127.0.0.1', 'port': 27017})
+    monkeypatch.setattr(Conf, 'MONGO', {'host': 'mongo', 'port': 27017})
     # check broker
     broker = get_broker(list_key='mongo_test')
     assert broker.ping() is True

--- a/django_q/tests/test_cluster.py
+++ b/django_q/tests/test_cluster.py
@@ -339,7 +339,6 @@ def test_bad_secret(broker, monkeypatch):
     monkeypatch.setattr(Conf, "SECRET_KEY", "OOPS")
     stat = Stat.get_all()
     assert len(stat) == 0
-    assert Stat.get(s.parent_pid) is None
     task_queue = Queue()
     pusher(task_queue, stop_event, broker=broker)
     result_queue = Queue()

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -283,7 +283,8 @@ To use Amazon SQS as a broker you need to provide the AWS region and credentials
         'sqs': {
             'aws_region': 'us-east-1',  # optional
             'aws_access_key_id': 'ac-Idr.....YwflZBaaxI',  # optional
-            'aws_secret_access_key': '500f7b....b0f302e9'  # optional
+            'aws_secret_access_key': '500f7b....b0f302e9',  # optional
+            'aws_sqs_url': 'http://localhost:9324',  # optional
         }
     }
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+-r /code/requirements.txt
+
+pytest
+pytest-django

--- a/test-services-docker-compose.yaml
+++ b/test-services-docker-compose.yaml
@@ -1,17 +1,48 @@
 version: '2.2'
 
 services:
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    env_file: .env
+    depends_on:
+      - disque
+      - redis
+      - mongo
+      - sqs
+    links:
+      - disque:disque
+      - redis:redis
+      - mongo:mongo
+      - sqs:sqs
+    volumes:
+      - .:/code
+
   disque:
     image: efrecon/disque:1.0-rc1
     ports:
       - '7711:7711/tcp'
+    expose:
+      - 7711
 
   redis:
     image: redis:latest
     ports:
       - '6379:6379/tcp'
+    expose:
+      - 6379
 
   mongo:
     image: mongo:4
     ports:
       - '27017:27017/tcp'
+    expose:
+      - 27017
+
+  sqs:
+    image: roribio16/alpine-sqs
+    ports:
+      - '9324:9324/tcp'
+    expose:
+      - 9324

--- a/test-services-docker-compose.yaml
+++ b/test-services-docker-compose.yaml
@@ -44,5 +44,6 @@ services:
     image: roribio16/alpine-sqs
     ports:
       - '9324:9324/tcp'
+      - '9325:9325/tcp'
     expose:
       - 9324

--- a/test-services-docker-compose.yaml
+++ b/test-services-docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '2.2'
 
 services:
-  test:
+  djangoq:
     build:
       context: .
       dockerfile: Dockerfile.test


### PR DESCRIPTION
Add support for an SQS Config option supplying an `endpoint_url` to the boto3 Resource. This primarily helps Docker-based development and local testing.

Also refactored the Docker workflow for running tests to be simpler and more self-contained. This utilizes the existing Docker images and a new one for SQS, and runs the test code within the container as well. (Note: the `ports` lines in `test-services-docker-compose.yaml` expose those ports to the host machine, which may not be necessary anymore)

This may allow the crazy binary stuff in `runtests.py` to go away, since the tests are much easier run with Docker now.

Updated the README for the testing changes, and updated docs for the new SQS config parameter.

Fixes https://github.com/Koed00/django-q/issues/396