### PR TITLE
Replacing `ugettext_` functions with `gettext_` for Django 3

### DIFF
--- a/django_q/admin.py
+++ b/django_q/admin.py
@@ -1,6 +1,6 @@
 """Admin module for Django."""
 from django.contrib import admin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_q.conf import Conf
 from django_q.models import Success, Failure, Schedule, OrmQ

--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -18,7 +18,7 @@ import traceback
 from django import db
 from django.conf import settings
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from multiprocessing import Event, Process, Value, current_process
 
 # Local

--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -4,7 +4,7 @@ from signal import signal
 from multiprocessing import cpu_count
 
 # django
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 
 # external
@@ -77,7 +77,7 @@ class Conf(object):
 
     # Guard loop sleep in seconds. Should be between 0 and 60 seconds.
     GUARD_CYCLE = conf.get('guard_cycle', 0.5)
-    
+
     # Disable the scheduler
     SCHEDULER = conf.get('scheduler', True)
 

--- a/django_q/management/commands/qcluster.py
+++ b/django_q/management/commands/qcluster.py
@@ -1,5 +1,5 @@
 from django.core.management.base import BaseCommand
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from django_q.cluster import Cluster
 

--- a/django_q/management/commands/qinfo.py
+++ b/django_q/management/commands/qinfo.py
@@ -1,5 +1,5 @@
 from django.core.management.base import BaseCommand
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from django_q import VERSION
 from django_q.conf import Conf

--- a/django_q/management/commands/qmonitor.py
+++ b/django_q/management/commands/qmonitor.py
@@ -1,5 +1,5 @@
 from django.core.management.base import BaseCommand
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from django_q.monitor import monitor
 

--- a/django_q/models.py
+++ b/django_q/models.py
@@ -3,7 +3,7 @@ from django.template.defaultfilters import truncatechars
 
 from django.urls import reverse
 from django.utils.html import format_html
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.db import models
 from django.utils import timezone
 from picklefield import PickledObjectField

--- a/django_q/monitor.py
+++ b/django_q/monitor.py
@@ -7,7 +7,7 @@ from blessed import Terminal
 from django.db import connection
 from django.db.models import Sum, F
 from django.utils import timezone
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 # local
 from django_q.conf import Conf

--- a/django_q/signals.py
+++ b/django_q/signals.py
@@ -2,7 +2,7 @@ import importlib
 
 from django.db.models.signals import post_save
 from django.dispatch import receiver, Signal
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_q.conf import logger
 from django_q.models import Task


### PR DESCRIPTION
The `ugettext_` series of functions have been deprecated in Django 3, since Python 2 is no longer supported. This PR removes those and replaces them with their `gettext_` alternatives.