### PR TITLE
Fix startup error in AWS Lambda

### DIFF
--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -156,7 +156,7 @@ class Conf(object):
     # OSX doesn't implement qsize because of missing sem_getvalue()
     try:
         QSIZE = Queue().qsize() == 0
-    except NotImplementedError:
+    except (NotImplementedError, OSError):
         QSIZE = False
 
     # Getting the signal names


### PR DESCRIPTION
Lambda has a similar issue with multiprocessing.Queue as OS X due to there being no /dev/shm, but it throws an OSError instead of NotImplementedError. Simple fix.