### PR TITLE
add windows support

### DIFF
--- a/django_q/queues.py
+++ b/django_q/queues.py
@@ -5,6 +5,7 @@ import sys
 
 import multiprocessing
 import multiprocessing.queues
+from multiprocessing import current_process
 
 
 class SharedCounter(object):
@@ -58,15 +59,21 @@ class Queue(multiprocessing.queues.Queue):
 
     def put(self, *args, **kwargs):
         super(Queue, self).put(*args, **kwargs)
+        if not hasattr(self, 'size'):
+            self.size = SharedCounter(0)
         self.size.increment(1)
 
     def get(self, *args, **kwargs):
         x = super(Queue, self).get(*args, **kwargs)
+        if not hasattr(self, 'size'):
+            self.size = SharedCounter(1)
         self.size.increment(-1)
         return x
 
     def qsize(self):
         """ Reliable implementation of multiprocessing.Queue.qsize() """
+        if not hasattr(self, 'size'):
+            self.size = SharedCounter(0)
         return self.size.value
 
     def empty(self):

--- a/django_q/queues.py
+++ b/django_q/queues.py
@@ -5,7 +5,6 @@ import sys
 
 import multiprocessing
 import multiprocessing.queues
-from multiprocessing import current_process
 
 
 class SharedCounter(object):


### PR DESCRIPTION
- windows multiprocessing uses the spawn start method which requires us to setup django, setup signals differently, not pass the broker (as it is not pickleable), and set django_q.queues.Queue.size as it does not properly pass the attribute
- added a fallback for looking up signal names