### PR TITLE
When sync=True, re-raise exceptions from the worker.

### DIFF
--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -424,6 +424,8 @@ def worker(task_queue, result_queue, timer, timeout=Conf.TIMEOUT):
                 result = (f"{e} : {traceback.format_exc()}", False)
                 if error_reporter:
                     error_reporter.report()
+                if task.get("sync", False):
+                    raise
         with timer.get_lock():
             # Process result
             task["result"] = result[0]

--- a/django_q/tests/tasks.py
+++ b/django_q/tests/tasks.py
@@ -1,6 +1,10 @@
 from time import sleep
 
 
+class TaskError(Exception):
+    pass
+
+
 def countdown(n):
     while n > 0:
         n -= 1
@@ -44,3 +48,7 @@ def hello():
 
 def result(obj):
     print(f"RESULT HOOK {obj.name} : {obj.result()}")
+
+
+def raise_exception():
+    raise TaskError("this is an exception!")

--- a/django_q/tests/test_cluster.py
+++ b/django_q/tests/test_cluster.py
@@ -18,7 +18,7 @@ from django_q.models import Task, Success
 from django_q.conf import Conf
 from django_q.status import Stat
 from django_q.brokers import get_broker, Broker
-from django_q.tests.tasks import multiply
+from django_q.tests.tasks import multiply, TaskError
 from django_q.queues import Queue
 
 
@@ -44,6 +44,11 @@ def test_redis_connection(broker):
 def test_sync(broker):
     task = async_task('django_q.tests.tasks.count_letters', DEFAULT_WORDLIST, broker=broker, sync=True)
     assert result(task) == 1506
+
+@pytest.mark.django_db
+def test_sync_raise_exception(broker):
+    with pytest.raises(TaskError):
+        async_task('django_q.tests.tasks.raise_exception', broker=broker, sync=True)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This commit adds code to detect if the task is running synchronously in
the worker and re-raise exceptions that were originally raised by the
underlying task function.