### PR TITLE
Do not decrement repeat counter for perpetually repeating Schedules

### DIFF
--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -590,7 +590,8 @@ def scheduler(broker=None):
                         if Conf.CATCH_UP or next_run > arrow.utcnow():
                             break
                     s.next_run = next_run.datetime
-                    s.repeats += -1
+                    if s.repeats > 0:
+                        s.repeats += -1
                 # send it to the cluster
                 q_options["broker"] = broker
                 q_options["group"] = q_options.get("group", s.name or s.id)


### PR DESCRIPTION
This PR prevents `Schedule.repeat` from being decremented when its value is negative - i.e. when the `Schedule` is configured to run forever.  

# Motivation

All `Schedule` instances where `.repeats` [is non-zero](https://github.com/Koed00/django-q/blob/master/django_q/cluster.py#L551-L553) are processed by `cluster.scheduler()`.  This includes both Schedules configured for a finite number of repeats, and those Schedules configured to repeat forever.

Before this PR, `cluster.scheduler()` did not distinguish between finite repeats and perpetual repeats when [decrementing](https://github.com/Koed00/django-q/blob/master/django_q/cluster.py#L593)  the `.repeat` field.  This caused a `.repeats` value that started at `-1` to have a value of `-501` after 500 runs of the Schedule.

# Implementation

Only decrement `Schedule.repeats` if its value is greater than zero.