### PR TITLE
empty dictionary as configuration value for SQS

### DIFF
--- a/django_q/brokers/__init__.py
+++ b/django_q/brokers/__init__.py
@@ -176,7 +176,7 @@ def get_broker(list_key: str = Conf.PREFIX) -> Broker:
 
         return ironmq.IronMQBroker(list_key=list_key)
     # SQS
-    elif Conf.SQS:
+    elif type(Conf.SQS) == dict:
         from django_q.brokers import aws_sqs
 
         return aws_sqs.Sqs(list_key=list_key)


### PR DESCRIPTION
The [documentation](https://django-q.readthedocs.io/en/latest/configure.html#sqs-configuration) lists all configuration keys for SQS as optional which will result in an empty dictionary as value. The way `get_broker` is implemented it will evaluate to false and return Redis. One way around this would be checking if the type of `Conf.SQS` is `dict`.