### PR TITLE
try to get SQS queue before creating it

### DIFF
--- a/django_q/brokers/aws_sqs.py
+++ b/django_q/brokers/aws_sqs.py
@@ -1,7 +1,11 @@
 from boto3 import Session
+from botocore.client import ClientError
 
 from django_q.brokers import Broker
 from django_q.conf import Conf
+
+
+QUEUE_DOES_NOT_EXIST = "AWS.SimpleQueueService.NonExistentQueue"
 
 
 class Sqs(Broker):
@@ -62,4 +66,13 @@ class Sqs(Broker):
 
     def get_queue(self):
         self.sqs = self.connection.resource("sqs")
+
+        try:
+            # try to return an existing queue by name. If the queue does not
+            # exist try to create it.
+            return self.sqs.get_queue_by_name(QueueName=self.list_key)
+        except ClientError as exp:
+            if not exp.response["Error"]["Code"] == QUEUE_DOES_NOT_EXIST:
+                raise exp
+
         return self.sqs.create_queue(QueueName=self.list_key)


### PR DESCRIPTION
In some environments permissions for an IAM role or access key might not include "SQS create".
The broker should first try to get the queue and if this fails try to create it which matches the current default behaviour.