### PR TITLE
Model.__unicode__() has no effect in Python 3.X

### DIFF
--- a/django_q/models.py
+++ b/django_q/models.py
@@ -97,7 +97,7 @@ class Task(models.Model):
     def short_result(self):
         return truncatechars(self.result, 100)
 
-    def __unicode__(self):
+    def __str__(self):
         return f"{self.name or self.id}"
 
     class Meta:
@@ -215,7 +215,7 @@ class Schedule(models.Model):
             return format_html(f'<a href="{url}">[{task.name}]</a>')
         return None
 
-    def __unicode__(self):
+    def __str__(self):
         return self.func
 
     success.boolean = True

--- a/django_q/tests/test_cluster.py
+++ b/django_q/tests/test_cluster.py
@@ -143,7 +143,7 @@ def test_enqueue(broker, admin_user):
     k = async_task('django_q.tests.tasks.get_user_id', admin_user,
                    q_options={'broker': broker, 'group': 'test_k', 'save': False, 'timeout': 90})
     # test unicode
-    assert Task(name='Amalia').__unicode__()=='Amalia'
+    assert Task(name='Amalia').__str__()=='Amalia'
     # check if everything has a task id
     assert isinstance(a, str)
     assert isinstance(b, str)

--- a/django_q/tests/test_scheduler.py
+++ b/django_q/tests/test_scheduler.py
@@ -100,7 +100,7 @@ def test_scheduler(broker, monkeypatch):
                                     cron="0 22 * * 1-5")
     assert hasattr(cron_schedule, 'pk') is True
     assert cron_schedule.full_clean() is None
-    assert cron_schedule.__unicode__() == 'django_q.tests.tasks.word_multiply'
+    assert cron_schedule.__str__() == 'django_q.tests.tasks.word_multiply'
     with pytest.raises(ValidationError):
         create_schedule('django_q.tests.tasks.word_multiply',
                         2,


### PR DESCRIPTION
This PR fixes displaying "Schedule object (1)" instead of Schedule.func in django-admin history & messages.
Python 2 support seems to be dropped, so I replaced __unicode__ with __str__.
Tested on Python 3.8.2, Django 3.1