### PR TITLE
[WIP]Change Django documentation links and URLs to a supported version (v1.8 -> v2.2)

### DIFF
--- a/django_q/tests/settings.py
+++ b/django_q/tests/settings.py
@@ -5,7 +5,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 # Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/1.8/howto/deployment/checklist/
+# See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = ')cqmpi+p@n&!u&fu@!m@9h&1bz9mwmstsahe)nf!ms+c$uc=x7'
@@ -61,7 +61,7 @@ TEMPLATES = [
 
 
 # Database
-# https://docs.djangoproject.com/en/1.8/ref/settings/#databases
+# https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
 DATABASES = {
     'default': {
@@ -72,7 +72,7 @@ DATABASES = {
 
 
 # Internationalization
-# https://docs.djangoproject.com/en/1.8/topics/i18n/
+# https://docs.djangoproject.com/en/2.2/topics/i18n/
 
 LANGUAGE_CODE = 'en-us'
 
@@ -101,7 +101,7 @@ LOGGING = {
 }
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.8/howto/static-files/
+# https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = '/static/'
 

--- a/docs/brokers.rst
+++ b/docs/brokers.rst
@@ -47,7 +47,7 @@ Bulk task retrieval is supported via the :ref:`bulk` option.
 
 * Delivery receipts
 * Atomic
-* Needs Django's `Cache framework <https://docs.djangoproject.com/en/1.8/topics/cache/#setting-up-the-cache>`__ configured for monitoring
+* Needs Django's `Cache framework <https://docs.djangoproject.com/en/2.2/topics/cache/#setting-up-the-cache>`__ configured for monitoring
 * Compatible with `Tynd <https://disque.tynd.co/>`__ Disque addon on `Heroku <https://heroku.com>`__
 * Still considered Alpha software
 * Supports bulk dequeue
@@ -60,7 +60,7 @@ This HTTP based queue service is both available directly via `Iron.io <http://ww
 
 * Delivery receipts
 * Supports bulk dequeue
-* Needs Django's `Cache framework <https://docs.djangoproject.com/en/1.8/topics/cache/#setting-up-the-cache>`__ configured for monitoring
+* Needs Django's `Cache framework <https://docs.djangoproject.com/en/2.2/topics/cache/#setting-up-the-cache>`__ configured for monitoring
 * Requires the `iron-mq <https://github.com/iron-io/iron_mq_python>`__ client library: ``pip install iron-mq``
 * See the :ref:`ironmq_configuration` configuration section for options.
 
@@ -72,7 +72,7 @@ Although `SQS <https://aws.amazon.com/sqs/>`__ is not the fastest, it is stable,
 * Delivery receipts
 * Maximum message size is 256Kb
 * Supports bulk dequeue up to 10 messages with a maximum total size of 256Kb
-* Needs Django's `Cache framework <https://docs.djangoproject.com/en/1.8/topics/cache/#setting-up-the-cache>`__ configured for monitoring
+* Needs Django's `Cache framework <https://docs.djangoproject.com/en/2.2/topics/cache/#setting-up-the-cache>`__ configured for monitoring
 * Requires the `boto3 <https://github.com/boto/boto3>`__ client library: ``pip install boto3``
 * See the :ref:`sqs_configuration` configuration section for options.
 
@@ -83,7 +83,7 @@ This highly scalable NoSQL database makes for a very fast and reliably persisten
 Usually available on most PaaS providers, as `open-source <https://www.mongodb.org/>`__ or commercial `enterprise <https://www.mongodb.com/lp/download/mongodb-enterprise>`__ edition.
 
 * Delivery receipts
-* Needs Django's `Cache framework <https://docs.djangoproject.com/en/1.8/topics/cache/#setting-up-the-cache>`__ configured for monitoring
+* Needs Django's `Cache framework <https://docs.djangoproject.com/en/2.2/topics/cache/#setting-up-the-cache>`__ configured for monitoring
 * Can be configured as the Django cache-backend through several open-source cache providers.
 * Requires the `pymongo <https://github.com/mongodb/mongo-python-driver>`__ driver: ``pip install pymongo``
 * See the :ref:`mongo_configuration` configuration section for options.
@@ -98,8 +98,8 @@ However for a medium message rate and scheduled tasks, this is the most convenie
 
 * Delivery receipts
 * Supports bulk dequeue
-* Needs Django's `Cache framework <https://docs.djangoproject.com/en/1.8/topics/cache/#setting-up-the-cache>`__ configured for monitoring
-* Can be `configured <https://docs.djangoproject.com/en/1.8/topics/cache/#database-caching>`__ as its own cache backend.
+* Needs Django's `Cache framework <https://docs.djangoproject.com/en/2.2/topics/cache/#setting-up-the-cache>`__ configured for monitoring
+* Can be `configured <https://docs.djangoproject.com/en/2.2/topics/cache/#database-caching>`__ as its own cache backend.
 * Queue editable in Django Admin
 * See the :ref:`orm_configuration` configuration on how to set it up.
 

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -400,7 +400,7 @@ Defaults to ``0.2`` (seconds).
 
 cache
 ~~~~~
-For some brokers, you will need to set up the Django `cache framework <https://docs.djangoproject.com/en/1.8/topics/cache/#setting-up-the-cache>`__
+For some brokers, you will need to set up the Django `cache framework <https://docs.djangoproject.com/en/2.2/topics/cache/#setting-up-the-cache>`__
 to gather statistics for the monitor. You can indicate which cache to use by setting this value. Defaults to ``default``.
 
 .. _cached:


### PR DESCRIPTION
This pull updates our documentation and code comments that link to the offical Django documentation to v2.2LTS. Currently they link to version 1.8 which is not supported by django-q, and is no longer supported by the Django team.

Users who follow the existing links will see a warning banner "This document is for an insecure version of Django that is no longer supported. Please upgrade to a newer release!".

NOTE: I wasn't sure which version to update them to I chose 2.2 because it's already used in the intersphinx_mapping in docs/conf.py. Alternatively we could update both to v3.1.

NOTE: I have not altered the CHANGELOG as I didn't want to presume a release, but I'm happy to do so.