### PR TITLE
Fix deprecation warning RemovedInDjango40Warning

### DIFF
--- a/django_q/signals.py
+++ b/django_q/signals.py
@@ -31,6 +31,8 @@ def call_hook(sender, instance, **kwargs):
                 )
             )
 
+# args: task
+pre_enqueue = Signal()
 
-pre_enqueue = Signal(providing_args=["task"])
-pre_execute = Signal(providing_args=["func", "task"])
+# args: func, task
+pre_execute = Signal()


### PR DESCRIPTION
RemovedInDjango40Warning: The providing_args argument is deprecated. As it is purely documentational, it has no replacement. If you rely on this argument as documentation, you can move the text to a code comment or docstring.