### PR TITLE
Add broker name in Schedule and enhanced Queued Tasks list display admin

### DIFF
--- a/django_q/admin.py
+++ b/django_q/admin.py
@@ -99,6 +99,9 @@ class QueueAdmin(admin.ModelAdmin):
     def has_add_permission(self, request):
         """Don't allow adds."""
         return False
+    
+    list_filter = ("key", "func")
+    search_fields = ("name", "func")
 
 
 admin.site.register(Schedule, ScheduleAdmin)

--- a/django_q/admin.py
+++ b/django_q/admin.py
@@ -100,8 +100,7 @@ class QueueAdmin(admin.ModelAdmin):
         """Don't allow adds."""
         return False
     
-    list_filter = ("key", "func")
-    search_fields = ("name", "func")
+    list_filter = ("key",)
 
 
 admin.site.register(Schedule, ScheduleAdmin)

--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -633,7 +633,12 @@ def scheduler(broker: Broker = None):
                     )
                     s.repeats += -1
                 # send it to the cluster
-                q_options["broker"] = broker
+                scheduled_broker = broker
+                try:
+                    scheduled_broker = get_broker(q_options["broker_name"])
+                except: # invalid broker_name or non existing broker with broker_name
+                    pass
+                q_options["broker"] = scheduled_broker
                 q_options["group"] = q_options.get("group", s.name or s.id)
                 kwargs["q_options"] = q_options
                 s.task = django_q.tasks.async_task(s.func, *args, **kwargs)

--- a/docs/schedules.rst
+++ b/docs/schedules.rst
@@ -28,10 +28,11 @@ You can manage them through the :ref:`admin_page` or directly from your code wit
                             )
 
     # In case you want to use q_options
+    # Specify the broker by using the property broker_name in q_options
     schedule('math.sqrt',
              9,
              hook='hooks.print_result',
-             q_options={'timeout': 30},
+             q_options={'timeout': 30, 'broker_name': 'broker_1'},
              schedule_type=Schedule.HOURLY)
 
     # Run a schedule every 5 minutes, starting at 6 today
@@ -117,6 +118,11 @@ Reference
     :param datetime next_run: Next or first scheduled execution datetime.
     :param dict q_options: options passed to async_task for this schedule
     :param kwargs: optional keyword arguments for the scheduled function.
+    
+    .. note::
+
+        q_options does not accept the 'broker' key with a broker instance but accepts a 'broker_name' key instead. This can be used to specify the broker connection name to assign the task. If a broker with the specified name does not exist or is not running at the moment of placing the task in queue it fallbacks to the random broker/queue that handled the schedule.
+
 
 .. class:: Schedule
 


### PR DESCRIPTION
This PR is somehow related to #107 . When we have several queues, the scheduled task is launched by a random queue (what is fine) but the task is also launched to be executed by the same queue what sometimes can delay it if the queue is very busy:

django_q/cluster.py (here)
```
# Call scheduler once a minute (or so)
  counter += cycle
  if counter >= 30 and Conf.SCHEDULER:
      counter = 0
      scheduler(broker=self.broker)
```

(and here)
```
def scheduler(broker: Broker = None):
    """
    Creates a task from a schedule at the scheduled time and schedules next run
    """
    if not broker:
        broker = get_broker()

.....

q_options["broker"] = broker
```

My PR solves it by assigning a variable 'broker_name' to 'q_options' dict when defining the Schedule Object. If the broker_name refers to an invalid/not running queue it fallbacks to the existing code.


Regardind the enhancement in Queued Tasks list display admin it is simply a filter by key.