### PR TITLE
added long pooling support for  sqs broker

### DIFF
--- a/django_q/brokers/aws_sqs.py
+++ b/django_q/brokers/aws_sqs.py
@@ -31,10 +31,10 @@ class Sqs(Broker):
 
         # sqs long pooling
         sqs_config = Conf.SQS
-        if 'sqs_receive_message_wait_time_seconds' in sqs_config:
-            wait_time_second = sqs_config.get('sqs_receive_message_wait_time_seconds', 20)
+        if 'receive_message_wait_time_seconds' in sqs_config:
+            wait_time_second = sqs_config.get('receive_message_wait_time_seconds', 20)
             if not isinstance(wait_time_second, int):
-                raise ValueError('sqs_receive_message_wait_time_seconds should be int')
+                raise ValueError('receive_message_wait_time_seconds should be int')
             params.update({'WaitTimeSeconds': wait_time_second})
 
         tasks = self.queue.receive_messages(**params)


### PR DESCRIPTION
added long pooling support in sqs broker .


need to add new receive_message_wait_time_seconds in config.sqs

eg:

Q_CLUSTER = {
    'name': 'test-queue',
    'sqs': {
        'aws_region': AWS_S3_REGION_NAME,
        'aws_access_key_id': AWS_ACCESS_KEY_ID,
        'aws_secret_access_key': AWS_SECRET_ACCESS_KEY,
        'receive_message_wait_time_seconds':20
    }
}