### PR TITLE
added long polling support 

### DIFF
--- a/django_q/brokers/aws_sqs.py
+++ b/django_q/brokers/aws_sqs.py
@@ -27,15 +27,19 @@ class Sqs(Broker):
         if Conf.BULK > 10:
             Conf.BULK = 10
 
-        params = {'MaxNumberOfMessages': Conf.BULK, 'VisibilityTimeout': Conf.RETRY}
+        params = {"MaxNumberOfMessages": Conf.BULK, "VisibilityTimeout": Conf.RETRY}
 
-        # sqs long pooling
+        # sqs long polling
         sqs_config = Conf.SQS
-        if 'receive_message_wait_time_seconds' in sqs_config:
-            wait_time_second = sqs_config.get('receive_message_wait_time_seconds', 20)
+        if "receive_message_wait_time_seconds" in sqs_config:
+            wait_time_second = sqs_config.get("receive_message_wait_time_seconds", 20)
+
+            # validation of parameter
             if not isinstance(wait_time_second, int):
-                raise ValueError('receive_message_wait_time_seconds should be int')
-            params.update({'WaitTimeSeconds': wait_time_second})
+                raise ValueError("receive_message_wait_time_seconds should be int")
+            if wait_time_second > 20:
+                raise ValueError("receive_message_wait_time_seconds is invalid. Reason: Must be >= 0 and <= 20")
+            params.update({"WaitTimeSeconds": wait_time_second})
 
         tasks = self.queue.receive_messages(**params)
         if tasks:
@@ -75,6 +79,9 @@ class Sqs(Broker):
         if "aws_region" in config:
             config["region_name"] = config["aws_region"]
             del config["aws_region"]
+
+        if 'receive_message_wait_time_seconds' in config:
+            del config["receive_message_wait_time_seconds"]
 
         return Session(**config)
 

--- a/django_q/brokers/aws_sqs.py
+++ b/django_q/brokers/aws_sqs.py
@@ -31,10 +31,10 @@ class Sqs(Broker):
 
         # sqs long pooling
         sqs_config = Conf.SQS
-        if 'sqs_receive_message_wait_time_seconds' in sqs_config:
-            wait_time_second = sqs_config.get('sqs_receive_message_wait_time_seconds', 20)
+        if 'receive_message_wait_time_seconds' in sqs_config:
+            wait_time_second = sqs_config.get('receive_message_wait_time_seconds', 20)
             if not isinstance(wait_time_second, int):
-                raise ValueError('sqs_receive_message_wait_time_seconds should be int')
+                raise ValueError('receive_message_wait_time_seconds should be int')
             params.update({'WaitTimeSeconds': wait_time_second})
 
         tasks = self.queue.receive_messages(**params)

--- a/django_q/tests/test_brokers.py
+++ b/django_q/tests/test_brokers.py
@@ -194,6 +194,7 @@ def canceled_sqs(monkeypatch):
             "aws_region": os.getenv("AWS_REGION"),
             "aws_access_key_id": os.getenv("AWS_ACCESS_KEY_ID"),
             "aws_secret_access_key": os.getenv("AWS_SECRET_ACCESS_KEY"),
+            "receive_message_wait_time_seconds": 20
         },
     )
     # check broker


### PR DESCRIPTION

introduce new parameter in broker sqs block
parameter for long polling is receive_message_wait_time_seconds

eg :
Q_CLUSTER = {
      'name': 'test-queue',
      'sqs': {
         'aws_region': AWS_S3_REGION_NAME,
         'aws_access_key_id': AWS_ACCESS_KEY_ID,
         'aws_secret_access_key': AWS_SECRET_ACCESS_KEY,
         'receive_message_wait_time_seconds':20
     }
}