### PR TITLE
Feature: save_limit per task group

### DIFF
--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -476,7 +476,8 @@ def save_task(task, broker: Broker):
     # SAVE LIMIT > 0: Prune database, SAVE_LIMIT 0: No pruning
     close_old_django_connections()
     try:
-        if task["success"] and 0 < Conf.SAVE_LIMIT <= Success.objects.count():
+        if task["success"] and (0 < Conf.SAVE_LIMIT <= Success.objects.count() or
+                                0 < Conf.SAVE_LIMIT_PER_GROUP <= Success.objects.filter(group=task['group']).count()):
             Success.objects.last().delete()
         # check if this task has previous results
         if Task.objects.filter(id=task["id"], name=task["name"]).exists():

--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -476,9 +476,11 @@ def save_task(task, broker: Broker):
     # SAVE LIMIT > 0: Prune database, SAVE_LIMIT 0: No pruning
     close_old_django_connections()
     try:
-        if task["success"] and (0 < Conf.SAVE_LIMIT <= Success.objects.count() or
-                                0 < Conf.SAVE_LIMIT_PER_GROUP <= Success.objects.filter(group=task['group']).count()):
+        if task["success"] and 0 < Conf.SAVE_LIMIT <= Success.objects.count():
             Success.objects.last().delete()
+        elif task["success"] and 0 < Conf.SAVE_LIMIT_PER_GROUP <= Success.objects.filter(group=task['group']).count():
+            Success.objects.filter(group=task['group']).last().delete()
+
         # check if this task has previous results
         if Task.objects.filter(id=task["id"], name=task["name"]).exists():
             existing_task = Task.objects.get(id=task["id"], name=task["name"])

--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -82,6 +82,8 @@ class Conf:
     # Failures are always saved
     SAVE_LIMIT = conf.get("save_limit", 250)
 
+    SAVE_LIMIT_PER_GROUP = conf.get("save_limit_per_group", 0)
+
     # Guard loop sleep in seconds. Should be between 0 and 60 seconds.
     GUARD_CYCLE = conf.get("guard_cycle", 0.5)
 


### PR DESCRIPTION
This implements the idea presented in #491.

To summarize the issue:
* I've got tasks that execute every 10 minutes. (group1)
* I've got tasks that execute once every week. (group2)
* I'd like to keep success messages of both groups in the database, without configuring `save_limit` to something very high (10000+ would be required here). It's also somewhat annoying that making a sane configuration here depends on the actual number of groups and their schedule.

Impact:

* Nothing changes with the default configuration.
* If `save_limit` is 0, and `save_limit_per_group` is greater than zero, `save_limit_per_group` takes effect.
* If both are greater than zero, both take effect at the same time, deleting old results whenever either `save_limit` or `save_limit_per_group` is exceeded.

Open points:

* This considers tasks with group=None to be one group as well.

If this is something you want, I'll also add relevant test cases and documentation.

