### PR TITLE
Add a warning  for misconfiguration.

### DIFF
--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -133,7 +133,7 @@ class Conf:
 
     # Verify if retry and timeout settings are correct
     if not TIMEOUT or  (TIMEOUT > RETRY):
-        warn("""Retry and timeout are missconfigured. Set retry larger than timeout, 
+        warn("""Retry and timeout are misconfigured. Set retry larger than timeout, 
         failure to do so will cause the tasks to be retriggered before completion. 
         See https://django-q.readthedocs.io/en/latest/configure.html#retry for details.""")
         

--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -132,7 +132,7 @@ class Conf:
     RETRY = conf.get("retry", 60)
 
     # Verify if retry and timeout settings are correct
-    if (retry < timeout) or not timeout:
+    if (RETRY < TIMEOUT) or not TIMEOUT:
         warn("""Retry and timeout are missconfigured. Set retry larger than timeout, 
         failure to do so will cause the tasks to be retriggered before completion. 
         See https://django-q.readthedocs.io/en/latest/configure.html#retry for details.""")

--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -132,7 +132,7 @@ class Conf:
     RETRY = conf.get("retry", 60)
 
     # Verify if retry and timeout settings are correct
-    if (RETRY < TIMEOUT) or not TIMEOUT:
+    if not TIMEOUT or  (TIMEOUT > RETRY):
         warn("""Retry and timeout are missconfigured. Set retry larger than timeout, 
         failure to do so will cause the tasks to be retriggered before completion. 
         See https://django-q.readthedocs.io/en/latest/configure.html#retry for details.""")

--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -135,7 +135,7 @@ class Conf:
     if (retry < timeout) or not timeout:
         warn("""Retry and timeout are missconfigured. Set retry larger than timeout, 
         failure to do so will cause the tasks to be retriggered before completion. 
-        See https://django-q.readthedocs.io/en/latest/configure.html#retry for details."""
+        See https://django-q.readthedocs.io/en/latest/configure.html#retry for details.""")
         
     
     # Sets the amount of tasks the cluster will try to pop off the broker.

--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -3,6 +3,7 @@ import os
 from copy import deepcopy
 from multiprocessing import cpu_count
 from signal import signal
+from warnings import warn
 
 import pkg_resources
 from django.conf import settings
@@ -130,6 +131,13 @@ class Conf:
     # Only works with brokers that guarantee delivery. Defaults to 60 seconds.
     RETRY = conf.get("retry", 60)
 
+    # Verify if retry and timeout settings are correct
+    if (retry < timeout) or not timeout:
+        warn("""Retry and timeout are missconfigured. Set retry larger than timeout, 
+        failure to do so will cause the tasks to be retriggered before completion. 
+        See https://django-q.readthedocs.io/en/latest/configure.html#retry for details."""
+        
+    
     # Sets the amount of tasks the cluster will try to pop off the broker.
     # If it supports bulk gets.
     BULK = conf.get("bulk", 1)
@@ -189,8 +197,7 @@ class Conf:
 
     # to manage workarounds during testing
     TESTING = conf.get("testing", False)
-
-
+    
 # logger
 logger = logging.getLogger("django-q")
 


### PR DESCRIPTION
As specified in the docs, by default the settings result in a configuration where slow tasks that run for more than 60s cause repeated running of tasks, which has caused a few issues. This warning doesn't change the defaults, which would be a marge larger change, but instead provides a, hopefully, helpful message to the user. 

This has caused issues before: https://github.com/Koed00/django-q/issues/183 and others. 

And it confused me, and only careful reading of the docs reveals this.