### PR TITLE
Add "qmemory" command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,10 @@ Monitor your clusters with::
 
     $ python manage.py qmonitor
 
+Monitor your clusters' memory usage with::
+
+    $ python manage.py qmemory
+
 Check overall statistics with::
 
     $ python manage.py qinfo

--- a/django_q/management/commands/qmemory.py
+++ b/django_q/management/commands/qmemory.py
@@ -1,0 +1,12 @@
+from django.core.management.base import BaseCommand
+from django.utils.translation import gettext as _
+
+from django_q.monitor import memory
+
+
+class Command(BaseCommand):
+    # Translators: help text for qmemory management command
+    help = _("Monitors Q Cluster memory usage")
+
+    def handle(self, *args, **options):
+        memory()

--- a/django_q/management/commands/qmemory.py
+++ b/django_q/management/commands/qmemory.py
@@ -8,5 +8,14 @@ class Command(BaseCommand):
     # Translators: help text for qmemory management command
     help = _("Monitors Q Cluster memory usage")
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--run-once",
+            action="store_true",
+            dest="run_once",
+            default=False,
+            help="Run once and then stop.",
+        )
+
     def handle(self, *args, **options):
-        memory()
+        memory(run_once=options.get("run_once", False))

--- a/django_q/management/commands/qmemory.py
+++ b/django_q/management/commands/qmemory.py
@@ -16,6 +16,16 @@ class Command(BaseCommand):
             default=False,
             help="Run once and then stop.",
         )
+        parser.add_argument(
+            "--workers",
+            action="store_true",
+            dest="workers",
+            default=False,
+            help="Show each worker's memory usage.",
+        )
 
     def handle(self, *args, **options):
-        memory(run_once=options.get("run_once", False))
+        memory(
+            run_once=options.get("run_once", False),
+            workers=options.get("workers", False)
+        )

--- a/django_q/monitor.py
+++ b/django_q/monitor.py
@@ -287,7 +287,7 @@ def info(broker=None):
     return True
 
 
-def memory(run_once=False, broker=None):
+def memory(run_once=False, workers=False, broker=None):
     if not broker:
         broker = get_broker()
     term = Terminal()
@@ -392,30 +392,31 @@ def memory(run_once=False, broker=None):
                 )
                 row += 1
             # each worker's memory usage
-            row += 2
-            col_width = int(term.width / (1 + Conf.WORKERS))
-            print(
-                term.move(row, 0 * col_width)
-                + term.black_on_cyan(term.center(_("Id"), width=col_width - 1))
-            )
-            for worker_num in range(Conf.WORKERS):
-                print(
-                    term.move(row, (worker_num + 1) * col_width)
-                    + term.black_on_cyan(term.center("Worker #{} (MB)".format(worker_num + 1), width=col_width - 1))
-                )
-            row += 2
-            for stat in stats:
+            if workers:
+                row += 2
+                col_width = int(term.width / (1 + Conf.WORKERS))
                 print(
                     term.move(row, 0 * col_width)
-                    + term.center(str(stat.cluster_id)[-8:], width=col_width - 1)
+                    + term.black_on_cyan(term.center(_("Id"), width=col_width - 1))
                 )
-                for idx, worker_pid in enumerate(stat.workers):
-                    mb_used = get_process_mb(worker_pid)
+                for worker_num in range(Conf.WORKERS):
                     print(
-                        term.move(row, (idx + 1) * col_width)
-                        + term.center(mb_used, width=col_width - 1)
+                        term.move(row, (worker_num + 1) * col_width)
+                        + term.black_on_cyan(term.center("Worker #{} (MB)".format(worker_num + 1), width=col_width - 1))
                     )
-                row += 1
+                row += 2
+                for stat in stats:
+                    print(
+                        term.move(row, 0 * col_width)
+                        + term.center(str(stat.cluster_id)[-8:], width=col_width - 1)
+                    )
+                    for idx, worker_pid in enumerate(stat.workers):
+                        mb_used = get_process_mb(worker_pid)
+                        print(
+                            term.move(row, (idx + 1) * col_width)
+                            + term.center(mb_used, width=col_width - 1)
+                        )
+                    row += 1
             row += 1
             print(
                 term.move(row, 0)

--- a/django_q/monitor.py
+++ b/django_q/monitor.py
@@ -278,7 +278,7 @@ def info(broker=None):
     return True
 
 
-def memory(broker=None):
+def memory(run_once=False, broker=None):
     if not broker:
         broker = get_broker()
     term = Terminal()
@@ -438,7 +438,9 @@ def memory(broker=None):
                     MEMORY_AVAILABLE_LOWEST_PERCENTAGE_AT.strftime('%Y-%m-%d %H:%M:%S+00:00')
                 )
             )
-            # Input
+            # for testing
+            if run_once:
+                return Stat.get_all(broker=broker)
             print(term.move(row + 2, 0) + term.center("[Press q to quit]"))
             val = term.inkey(timeout=1)
 

--- a/django_q/tests/test_commands.py
+++ b/django_q/tests/test_commands.py
@@ -17,3 +17,8 @@ def test_qinfo():
     call_command('qinfo')
     call_command('qinfo', config=True)
     call_command('qinfo', ids=True)
+
+
+@pytest.mark.django_db
+def test_qmemory():
+    call_command('qmemory', run_once=True)

--- a/django_q/tests/test_commands.py
+++ b/django_q/tests/test_commands.py
@@ -22,3 +22,4 @@ def test_qinfo():
 @pytest.mark.django_db
 def test_qmemory():
     call_command('qmemory', run_once=True)
+    call_command('qmemory', workers=True, run_once=True)


### PR DESCRIPTION
Shows the following info for each cluster:

- Cluster ID
- State
- Uptime
- Available memory (MB)
- Available memory (%)
- Total memory (MB)
- Memory usage of each worker (MB)

Also tracks lowest available memory (%) with a timestamp. And has the same bottom blue bar info as in `qmonitor` (Queued/Successful/Failed tasks).

Not exactly sure if all the info is necessary or if I should add something more. I myself was interested in memory related info, uptime, number of queued tasks and which cluster was in question.