### PR TITLE
Fix for SSL errors in #422  

### DIFF
--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -210,7 +210,8 @@ class Sentinel:
         :param process: the process to reincarnate
         :type process: Process or None
         """
-        close_old_django_connections()
+        if not Conf.SYNC:
+            db.connections.close_all()  # Close any old connections
         if process == self.monitor:
             self.monitor = self.spawn_monitor()
             logger.error(_(f"reincarnated monitor {process.name} after sudden death"))
@@ -234,7 +235,8 @@ class Sentinel:
     def spawn_cluster(self):
         self.pool = []
         Stat(self).save()
-        close_old_django_connections()
+        if not Conf.SYNC:
+            db.connection.close()
         # spawn worker pool
         for __ in range(self.pool_size):
             self.spawn_worker()


### PR DESCRIPTION
After verifying the fix proposed by @cveilleux in https://github.com/Koed00/django-q/issues/422#issuecomment-736577062
What I've done in `cluster.py`:

- `reincarnate`: removed `close_old_django_connections()` and replaced with `db.connections.close_all()` when `Conf.SYNC` is not True
- `spawn_cluster`: removed `close_old_django_connections()` and replace with `db.connection.close()` when `Conf.SYNC` is not True

This commit passes `pytest`.