### PR TITLE
Fix RemovedInDjango41Warning 

### DIFF
--- a/django_q/__init__.py
+++ b/django_q/__init__.py
@@ -1,6 +1,8 @@
 VERSION = (1, 3, 8)
 
-default_app_config = "django_q.apps.DjangoQConfig"
+import django
 
+if django.VERSION < (3, 2):
+    default_app_config = "django_q.apps.DjangoQConfig"
 
 __all__ = ["conf", "cluster", "models", "tasks"]


### PR DESCRIPTION
Fixes 
```
RemovedInDjango41Warning: 'django_q' defines default_app_config = 'django_q.apps.DjangoQConfig'. Django now detects this configuration automatically. You can remove default_app_config.
```