### PR TITLE
fix long polling support for Amazon SQS

### DIFF
--- a/django_q/brokers/aws_sqs.py
+++ b/django_q/brokers/aws_sqs.py
@@ -31,8 +31,8 @@ class Sqs(Broker):
 
         # sqs long polling
         sqs_config = Conf.SQS
-        if "receive_message_wait_time_seconds" in sqs_config:
-            wait_time_second = sqs_config.get("receive_message_wait_time_seconds", 20)
+        if Conf.SQS_RECEIVE_MESSAGE_WAIT_TIME_SECONDS:
+            wait_time_second = Conf.SQS_RECEIVE_MESSAGE_WAIT_TIME_SECONDS
 
             # validation of parameter
             if not isinstance(wait_time_second, int):
@@ -81,9 +81,6 @@ class Sqs(Broker):
         if "aws_region" in config:
             config["region_name"] = config["aws_region"]
             del config["aws_region"]
-
-        if "receive_message_wait_time_seconds" in config:
-            del config["receive_message_wait_time_seconds"]
 
         return Session(**config)
 

--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -60,6 +60,14 @@ class Conf:
     # SQS broker
     SQS = conf.get("sqs", None)
 
+    # SQS long polling support
+    SQS_RECEIVE_MESSAGE_WAIT_TIME_SECONDS = conf.get("receive_message_wait_time_seconds", None)
+
+    # Check for receive_message_wait_time_seconds in SQS for backward compatibility
+    if SQS and "receive_message_wait_time_seconds" in SQS:
+        SQS_RECEIVE_MESSAGE_WAIT_TIME_SECONDS = SQS.get("receive_message_wait_time_seconds", 0)
+        del SQS["receive_message_wait_time_seconds"]
+
     # ORM broker
     ORM = conf.get("orm", None)
 


### PR DESCRIPTION
As mentioned in https://github.com/Koed00/django-q/pull/506#issuecomment-835413579 long polling on Amazon SQS is not working in the current build, as the parameter receive_message_wait_time_seconds is removed from the configuration in the get_connection method of the Sqs broker, and is therefore never used.

I have moved the parameter outside of the sqs key in the broker definition to make it work the same way as the other optional parameters and make the value available to the broker through the Conf object:

`Q_CLUSTER = {
    'name': SQS_QUEUE_NAME,
    'workers': 2,
    'timeout': 90,
    'retry': 120,
    'queue_limit': 50,
    'bulk': 5,
    'max-attempts': 10,
    'receive_message_wait_time_seconds': 10,
    'sqs': {
        'aws_region': 'eu-west-1',
        'aws_access_key_id': '',
        'aws_secret_access_key': '',
    }
}`

I also added a test to look for the parameter inside the 'sqs' parameter, to make this backward compatible with #506 
