### PR TITLE
Fix connection issues with CONN_MAX_AGE > 0

### DIFF
--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -213,8 +213,9 @@ class Sentinel:
         :param process: the process to reincarnate
         :type process: Process or None
         """
+        # close connections before spawning new process
         if not Conf.SYNC:
-            db.connections.close_all()  # Close any old connections
+            db.connections.close_all()
         if process == self.monitor:
             self.monitor = self.spawn_monitor()
             logger.error(_(f"reincarnated monitor {process.name} after sudden death"))
@@ -238,8 +239,9 @@ class Sentinel:
     def spawn_cluster(self):
         self.pool = []
         Stat(self).save()
+        # close connections before spawning new process
         if not Conf.SYNC:
-            db.connection.close()
+            db.connections.close_all()
         # spawn worker pool
         for __ in range(self.pool_size):
             self.spawn_worker()
@@ -692,7 +694,7 @@ def close_old_django_connections():
         logger.warning(
             "Preserving django database connections because sync=True. Beware "
             "that tasks are now injected in the calling context/transactions "
-            "which may result in unexpected bahaviour."
+            "which may result in unexpected behaviour."
         )
     else:
         db.close_old_connections()


### PR DESCRIPTION
For proper operation with CONN_MAX_AGE is > 0 we have to make sure that connection objects are no shared between parent and child processes.

Proposed change is to replace db.connection.close() by db.connections.close_all() in spawn_cluster().

Related open issues : #589 #486 #484 #471 #435 

This has only been tested on linux, not on MacOS or Windows, as I currently don't have a way to test on those environments.