### PR TITLE
Admin improvements

### DIFF
--- a/django_q/admin.py
+++ b/django_q/admin.py
@@ -79,7 +79,7 @@ class ScheduleAdmin(admin.ModelAdmin):
         readonly_fields = ("cron",)
 
     list_filter = ("next_run", "schedule_type", "cluster")
-    search_fields = ("func",)
+    search_fields = ("name", "func",)
     list_display_links = ("id", "name")
 
 

--- a/django_q/admin.py
+++ b/django_q/admin.py
@@ -86,7 +86,7 @@ class ScheduleAdmin(admin.ModelAdmin):
 class QueueAdmin(admin.ModelAdmin):
     """queue admin for ORM broker"""
 
-    list_display = ("id", "key", "task_id", "name", "func", "lock")
+    list_display = ("id", "key", "name",  "group", "func", "lock", "task_id")
 
     def save_model(self, request, obj, form, change):
         obj.save(using=Conf.ORM)

--- a/django_q/admin.py
+++ b/django_q/admin.py
@@ -10,7 +10,7 @@ from django_q.tasks import async_task
 class TaskAdmin(admin.ModelAdmin):
     """model admin for success tasks."""
 
-    list_display = ("name", "func", "started", "stopped", "time_taken", "group")
+    list_display = ("name", "group", "func", "started", "stopped", "time_taken")
 
     def has_add_permission(self, request):
         """Don't allow adds."""
@@ -43,14 +43,14 @@ retry_failed.short_description = _("Resubmit selected tasks to queue")
 class FailAdmin(admin.ModelAdmin):
     """model admin for failed tasks."""
 
-    list_display = ("name", "func", "started", "stopped", "short_result")
+    list_display = ("name", "group", "func", "started", "stopped", "short_result")
 
     def has_add_permission(self, request):
         """Don't allow adds."""
         return False
 
     actions = [retry_failed]
-    search_fields = ("name", "func")
+    search_fields = ("name", "func", "group")
     list_filter = ("group",)
     readonly_fields = []
 

--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -474,12 +474,21 @@ def save_task(task, broker: Broker):
     # SAVE LIMIT > 0: Prune database, SAVE_LIMIT 0: No pruning
     close_old_django_connections()
     try:
-        with db.transaction.atomic():
-            last = Success.objects.select_for_update().last()
-            if task["success"] and 0 < Conf.SAVE_LIMIT <= Success.objects.count():
-                last.delete()
+        if task["success"]:
+            # first apply per group success history limit
+            if "group" in task:
+                with db.transaction.atomic():
+                    qs = Success.objects.filter(group=task["group"])
+                    last = qs.select_for_update().last()
+                    if Conf.SAVE_LIMIT_PER_GROUP <= qs.count():
+                        last.delete()
+            # then apply global success history limit
+            with db.transaction.atomic():
+                last = Success.objects.select_for_update().last()
+                if Conf.SAVE_LIMIT <= Success.objects.count():
+                    last.delete()
         # check if this task has previous results
-        if Task.objects.filter(id=task["id"], name=task["name"]).exists():
+        try:
             existing_task = Task.objects.get(id=task["id"], name=task["name"])
             # only update the result if it hasn't succeeded yet
             if not existing_task.success:
@@ -494,8 +503,7 @@ def save_task(task, broker: Broker):
                 and existing_task.attempt_count >= Conf.MAX_ATTEMPTS
             ):
                 broker.acknowledge(task["ack_id"])
-
-        else:
+        except Task.DoesNotExist:
             func = task["func"]
             # convert func to string
             if inspect.isfunction(func):

--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -86,6 +86,10 @@ class Conf:
     # Failures are always saved
     SAVE_LIMIT = conf.get("save_limit", 250)
 
+    # Maximum number of successful tasks of the same group kept in the database. 0 saves everything. -1 saves none
+    # Failures are always saved
+    SAVE_LIMIT_PER_GROUP = conf.get("save_limit_per_group", 5)
+
     # Guard loop sleep in seconds. Should be between 0 and 60 seconds.
     GUARD_CYCLE = conf.get("guard_cycle", 0.5)
 
@@ -137,8 +141,8 @@ class Conf:
     # Verify if retry and timeout settings are correct
     if not TIMEOUT or (TIMEOUT > RETRY):
         warn(
-            """Retry and timeout are misconfigured. Set retry larger than timeout, 
-        failure to do so will cause the tasks to be retriggered before completion. 
+            """Retry and timeout are misconfigured. Set retry larger than timeout,
+        failure to do so will cause the tasks to be retriggered before completion.
         See https://django-q.readthedocs.io/en/latest/configure.html#retry for details."""
         )
 

--- a/django_q/models.py
+++ b/django_q/models.py
@@ -220,7 +220,10 @@ class Schedule(models.Model):
         return self.func
 
     success.boolean = True
+    success.short_description = _("success")
     last_run.allow_tags = True
+    last_run.short_description = _("last_run")
+
 
     class Meta:
         app_label = "django_q"

--- a/django_q/models.py
+++ b/django_q/models.py
@@ -246,6 +246,9 @@ class OrmQ(models.Model):
     def name(self):
         return self.task()["name"]
 
+    def group(self):
+        return self.task().get("group")
+
     class Meta:
         app_label = "django_q"
         verbose_name = _("Queued task")


### PR DESCRIPTION
Some minor improvements to django-admin interface to ease operations with scheduled tasks :
- Add group field to tasks list and search_field
- Add search by name to Schedule admin page
- Improve ScheduleAdmin list view performance 
- Add the group column to OrmQ admin page

I am also proposing to introduce a new setting SAVE_LIMIT_PER_GROUP, to limit the number of successful runs kept per schedule task. 
This is particularly useful when you have some tasks running every few minutes and some every week or month. Currently the first type of task fills the history and status of last_run for tasks running every week or month is lost.