### PR TITLE
Add 'retry' to opt_keys in 'async_task'

### DIFF
--- a/django_q/tasks.py
+++ b/django_q/tasks.py
@@ -32,6 +32,7 @@ def async_task(func, *args, **kwargs):
         "chain",
         "broker",
         "timeout",
+        "retry",
     )
     q_options = keywords.pop("q_options", {})
     # get an id

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -59,6 +59,13 @@ Overrides the cluster's timeout setting for this task.
 
 See :ref:`retry` for details how to set values for timeout.
 
+retry
+"""""
+Adds custom `retry` value for this task.
+
+Note that you have to implement your custom broker in order
+to make use of this value and override the cluster's retry setting.
+
 ack_failure
 """""""""""
 Overrides the cluster's :ref:`ack_failures` setting for this task.

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -64,7 +64,7 @@ retry
 Adds custom `retry` value for this task.
 
 Note that you have to implement your custom broker in order
-to make use of this value and override the cluster's retry setting.
+to override the cluster's retry setting by using this value.
 
 ack_failure
 """""""""""


### PR DESCRIPTION
Hi again @Koed00 

I'd like to add `retry` to opt_keys in `async_task`. We have implemented our own custom ORM broker that makes use of custom retry value like this:

```python
def _timeout(retry=None):
    retry = retry or Conf.RETRY
    return timezone.now() - timedelta(seconds=retry)


class ORM(BaseORM):

    def enqueue(self, task):
        data = SignedPackage.loads(task)
        retry = data.get('retry')
        package = self.get_connection().create(
            key=self.list_key, payload=task, lock=_timeout(retry)
        )
        return package.pk

    def dequeue(self):
        # Query queued tasks using default _timeout
        tasks = self.get_connection().filter(key=self.list_key, lock__lt=_timeout())[
            0:Conf.BULK
        ]
        if tasks:
            task_list = []
            for task in tasks:
                # Check here if task has custom timeout. If lock
                # is greater than custom timeout time, skip
                retry = task.task().get('retry')
                if task.lock > _timeout(retry):
                    continue
                if (
                    self.get_connection()
                    .filter(id=task.id, lock=task.lock)
                    .update(lock=timezone.now())
                ):
                    task_list.append((task.pk, task.payload))
                # else don't process, as another cluster has been faster than us on that task
            return task_list
        # empty queue, spare the cpu
        sleep(Conf.POLL)

```

This isn't at the moment possible because `retry` is missing from opt_keys and thus not added in the task payload data.