### PR TITLE
Define [build-system] in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,9 +67,11 @@ pytest-cov = "^2.12.0"
 black = { version = "^21.5b1", allow-prereleases = true }
 isort = {extras = ["requirements_deprecated_finder"], version = "^5.8.0"}
 
-[tool.poetry.extras]
+[build-system]
 requires = ["poetry_core>=1.0.0"]
-build-backend = ["poetry.core.masonry.api"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.extras]
 testing = ["django-redis", "croniter", "hiredis", "psutil", "iron-mq", "boto3", "pymongo"]
 rollbar = ["django-q-rollbar"]
 sentry = ["django-q-sentry"]


### PR DESCRIPTION
So that PEP-517 tools like `build` know how to build the package from source.