### PR TITLE
Do not run expensive query in save_task if SAVE_LIMIT is 0

### DIFF
--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -474,10 +474,11 @@ def save_task(task, broker: Broker):
     # SAVE LIMIT > 0: Prune database, SAVE_LIMIT 0: No pruning
     close_old_django_connections()
     try:
-        with db.transaction.atomic():
-            last = Success.objects.select_for_update().last()
-            if task["success"] and 0 < Conf.SAVE_LIMIT <= Success.objects.count():
-                last.delete()
+        if Conf.SAVE_LIMIT > 0:
+            with db.transaction.atomic():
+                last = Success.objects.select_for_update().last()
+                if task["success"] and Conf.SAVE_LIMIT <= Success.objects.count():
+                    last.delete()
         # check if this task has previous results
         if Task.objects.filter(id=task["id"], name=task["name"]).exists():
             existing_task = Task.objects.get(id=task["id"], name=task["name"])


### PR DESCRIPTION
Check if SAVE_LIMIT is bigger than 0 before running any queries.

On MS SQL Server, the select_for_update() query below will take a ROWLOCK,UPDLOCK on every row in the Task table. This happens because it locks every row it needs to look at to return the result of the query. Since there is no index on the default sorting column "stopped", it has to do a full table scan, and hence it will take rowlocks on each row in the table.
On other databases, it will still do a full table scan, but without the excessive locking.
If SAVE_LIMIT is 0 the result of this query is unused, so by moving the check a level higher we avoid running this expensive query.

It might also be a good idea to optimize the query if SAVE_LIMIT is not 0, for example by putting an index on the stopped column, or by ordering this query by pk instead of the stopped column.