### PR TITLE
pyproject.toml: move build-system bits where they belong

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,6 @@ black = { version = "^21.5b1", allow-prereleases = true }
 isort = {extras = ["requirements_deprecated_finder"], version = "^5.8.0"}
 
 [tool.poetry.extras]
-requires = ["poetry_core>=1.0.0"]
-build-backend = ["poetry.core.masonry.api"]
 testing = ["django-redis", "croniter", "hiredis", "psutil", "iron-mq", "boto3", "pymongo"]
 rollbar = ["django-q-rollbar"]
 sentry = ["django-q-sentry"]
@@ -77,3 +75,7 @@ sentry = ["django-q-sentry"]
 [tool.isort]
 profile = "black"
 multi_line_output = 3
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
These had been misplaced in 5d3f9fd9168054c3414591304dcbbe1614fb333a.

Moving them back to the `[build-system]` section makes this package compliant with PEP 517, and e.g. installing from a `git+` URL (or a working copy) works once more:

## 85baaccd

```
$ pip install /repo
Processing /repo
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Building wheels for collected packages: UNKNOWN
  Building wheel for UNKNOWN (PEP 517) ... done
  Created wheel for UNKNOWN: filename=UNKNOWN-0.0.0-py3-none-any.whl size=1803 sha256=20f675a1a4ffc1e82b9102e96139701b0b73bfd2f1c21f5bff73a5f98473e86e
Successfully built UNKNOWN
Installing collected packages: UNKNOWN
```

## this PR

```
# pip install /repo
Processing /repo
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Collecting dependencies
Building wheels for collected packages: django-q
  Building wheel for django-q (PEP 517) ... done
  Created wheel for django-q: filename=django_q-1.3.9-py3-none-any.whl size=89882 sha256=133626bc462890c671cca41183a4581b027745230714dff79a7eef57f836a5ba
Successfully built django-q
Installing collected packages: sqlparse, six, asgiref, wcwidth, python-dateutil, django, redis, django-picklefield, blessed, arrow, django-q