### PR TITLE
allow atomic on external db

### DIFF
--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -474,7 +474,8 @@ def save_task(task, broker: Broker):
     # SAVE LIMIT > 0: Prune database, SAVE_LIMIT 0: No pruning
     close_old_django_connections()
     try:
-        with db.transaction.atomic():
+        database_to_use = {"using": Conf.ORM if Conf.ORM else Schedule.objects.db} if not Conf.HAS_REPLICA else {}
+        with db.transaction.atomic(**database_to_use):
             last = Success.objects.select_for_update().last()
             if task["success"] and 0 < Conf.SAVE_LIMIT <= Success.objects.count():
                 last.delete()
@@ -583,7 +584,7 @@ def scheduler(broker: Broker = None):
         broker = get_broker()
     close_old_django_connections()
     try:
-        database_to_use = {"using": Conf.ORM} if not Conf.HAS_REPLICA else {}
+        database_to_use = {"using": Conf.ORM if Conf.ORM else Schedule.objects.db} if not Conf.HAS_REPLICA else {}
         with db.transaction.atomic(**database_to_use):
             for s in (
                 Schedule.objects.select_for_update()


### PR DESCRIPTION
as described in the issue #652 
django-q queries a lot for tasks and schedules.
to keep django-q on a different db, preferably on a no-sql db
while the main app in on a sql db and still use a different broker like redis.

the solution prevents transaction lock on different databases by using the db-route.