### PR TITLE
Use logger.hasHandlers() to setup fallback logging

### DIFF
--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -207,7 +207,7 @@ class Conf:
 logger = logging.getLogger("django-q")
 
 # Set up standard logging handler in case there is none
-if not logger.handlers:
+if not logger.hasHandlers():
     logger.setLevel(level=getattr(logging, Conf.LOG_LEVEL))
     logger.propagate = False
     formatter = logging.Formatter(


### PR DESCRIPTION
Instead of checking if the django-q logger has any handlers directly, use the [hasHandlers](https://docs.python.org/3/library/logging.html#logging.Logger.hasHandlers) method, which will check if any parent loggers have handlers as well.

This fixes a bug where django-q configures it's own logging even though the root logger has a handler set

```python
import logging

root_logger = logging.getLogger()
django_q_logger = logging.getLogger("django-q")

print("list of djando_q handlers", django_q_logger.handlers)
# []
print("does django_q have handlers?", django_q_logger.hasHandlers())
# False

root_logger.addHandler(logging.StreamHandler())

print("list of djando_q handlers", django_q_logger.handlers)
# []
print("does django_q have handlers?", django_q_logger.hasHandlers())
# True
```
