### PR TITLE
Fix error in example code

### DIFF
--- a/docs/schedules.rst
+++ b/docs/schedules.rst
@@ -44,7 +44,7 @@ You can manage them through the :ref:`admin_page` or directly from your code wit
              schedule_type=Schedule.MINUTES,
              minutes=5,
              repeats=24,
-             next_run=arrow.utcnow().replace(hour=18, minute=0))
+             next_run=arrow.utcnow().replace(hour=18, minute=0).datetime)
 
     # Use a cron expression
     schedule('math.hypot',


### PR DESCRIPTION
The example code for running a schedule every 5 minutes, starting at 6pm for 2 hours is not working actually. 
The error code is `TypeError: expected string or bytes-like object`

Made a fix by adding a datetime call after replace().