### PR TITLE
Fix syntax error in example

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -104,7 +104,7 @@ For example, with the following code
 
    # settings.py
    Q_CLUSTER = {
-      'retry': 5
+      'retry': 5,
       'workers': 4,
       'orm': 'default',
    }


### PR DESCRIPTION
This page (section) is linked to from django's error message... so initially I copy/pasted this...to my config, which then resulted in a worse error message, as the comma was missing. So fixing this in the docs ;)